### PR TITLE
Add REST API routes for custom post types for syncing

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -120,7 +120,8 @@ function create_post_type_team()
         'taxonomies' => array(
             'post_tag',
             'category'
-        )
+        ),
+        'show_in_rest' => true
     ));
 }
 
@@ -233,7 +234,8 @@ function create_post_type_languages()
         'taxonomies' => array(
             'post_tag',
             'category'
-        )
+        ),
+        'show_in_rest' => true
     ));
 }
 
@@ -272,7 +274,8 @@ function create_post_type_videos()
         'taxonomies' => array(
             'post_tag',
             'category'
-        )
+        ),
+        'show_in_rest' => true
     ));
 }
 
@@ -350,7 +353,8 @@ function create_post_type_resources()
         'taxonomies' => array(
             'post_tag',
             'category'
-        )
+        ),
+        'show_in_rest' => true
     ));
 }
 


### PR DESCRIPTION
Set `'show_in_rest' => true` for the post types that we actively sync - `videos`, `languages`, `team`, and `resources`.

Ran the local web server and checked wp-json and saw new routes for these post types, so hopefully that'll make the syncing work!