### PR TITLE
Refine the language search query

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/modules/languages-search.php
+++ b/modules/languages-search.php
@@ -30,28 +30,66 @@
 
 		if ($languages_search) {
 			echo '<h2 class="wt_search__results--title">Showing results for \'' . $languages_search . '\'</h2>'; 
-
 		} 
 
 		if (!empty($languages_search)) {
-			$args['meta_query'] = array(
-				array(
-					'key' => 'wt_id',
-					'value' => $languages_search,
-					'compare' => 'LIKE'
-				),
-				array(
-					'key' => 'standard_name',
-					'value' => $languages_search,
-					'compare' => 'LIKE'
-				),
-				array(
-					'key' => 'alternate_names',
-					'value' => $languages_search,
-					'compare' => 'LIKE'
-				),
-				'relation' => 'OR'
-			);
+			$iso_code_regex = '#^w?[a-z]{3}$#';  // Also accounts for 4-letter Wikitongues-assigned codes
+			$glottocode_regex = '#^[[:alnum:]]{4}\d{4}$#';
+			preg_match($iso_code_regex, $languages_search, $iso_match);
+			preg_match($glottocode_regex, $languages_search, $glottocode_match);
+
+			if ($iso_match) {
+				$args['meta_query'] = array(
+					array(
+						'key' => 'iso_code',
+						'value' => $languages_search,
+						'compare' => '='
+					),
+					array(
+						'key' => 'standard_name',
+						'value' => $languages_search,
+						'compare' => '='
+					),
+					'relation' => 'OR'
+				);
+			} else if ($glottocode_match) {
+				$args['meta_query'] = array(
+					array(
+						'key' => 'glottocode',
+						'value' => $languages_search,
+						'compare' => '='
+					)
+				);
+			} else {
+				$args['meta_query'] = array(
+					array(
+						'key' => 'standard_name',
+						'value' => $languages_search,
+						'compare' => 'LIKE'
+					),
+					array(
+						'key' => 'alternate_names',
+						'value' => $languages_search,
+						'compare' => 'LIKE'
+					),
+					array(
+						'key' => 'nations_of_origin',
+						'value' => $languages_search,
+						'compare' => 'LIKE'
+					),
+					array(
+						'key' => 'writing_systems',
+						'value' => $languages_search,
+						'compare' => 'LIKE'
+					),
+					array(
+						'key' => 'linguistic_genealogy',
+						'value' => $languages_search,
+						'compare' => '='
+					),
+					'relation' => 'OR'
+				);
+			}
 		}
 
 		// Get current page and append to custom query parameters array


### PR DESCRIPTION
# Details

Refined search query so that we can search by a variety of fields, and results are more relevant when searching by ISO code. The tradeoff is increased page load time.

* Search by standard name, alternate names, nations, writing systems, and genealogies
  * Use exact match for genealogies, otherwise there are so many "English Creole" languages that "English [eng]" does not appear in the first 10 results
  * Use `LIKE` comparison for other fields
* If query is a valid ISO code, search for exact match of ISO code or standard name
* If query is a valid glottocode, search for exact match by glottocode

# Test plan

* Ran searches on local website before and after code change
* Measured load time in Chrome Dev Tools Network tab

| Query | Results [Before] | Results [After] | Load Time [Before] | Load Time [After] |
| ----- | ---------------- | --------------- | ------------- | ------------ |
| english | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | 3.21 s | 5.92 s
| nglish | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | 2.84 s | 4.79 s
| englis | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bajan [bjs], Broome Pearling Lugger Pidgin [bpl], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Chinese Pidgin English [cpi], English [eng], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | 2.64 s | 5.36 s
| eng | Agavotaguerra [avo], Benga [bng], Maring [mbw], Nzanyi [nja], Woiwurrung [wyi], Argentine Sign Language [aed], Antigua and Barbuda Creole English [aig], Angal Heneng [akh], Angal Enen [aoe], Apurinã [apu]  | English [eng] | 2.81 s | 2.08 s
| english creole | | Afro-Seminole Creole [afs], Antigua and Barbuda Creole English [aig], Bahamas Creole English [bah], Bislama [bis], Bajan [bjs], Belize Kriol English [bzj], Nicaragua Creole English [bzk], Eastern Maroon Creole [djk], Equatorial Guinean Pidgin [fpe], Grenadian Creole English [gcl] | 1.85 s | 5.43 s
| spanish | Ladino [lad], Spanish [spa], Spanish, Loreto-Ucayali [spq], Spanish Sign Language [ssp] | Ladino [lad], Spanish [spa], Spanish, Loreto-Ucayali [spq], Spanish Sign Language [ssp] | 1.97 s | 4.61 s
| spanish creole | | Chavacano [cbk], Palenquero [pln] | 1.97 s | 5.96 s
| chinese | Aceh [ace], Chinese, Min Dong [cdo], Chinese, Jinyu [cjy], Chinese, Mandarin [cmn], Chinese Pidgin English [cpi], Chinese, Pu-Xian [cpx], Chinese Sign Language [csl], Chinese, Huizhou [czh], Chinese, Min Zhong [czo], Chinese, Gan [gan] | Aceh [ace], Chinese, Min Dong [cdo], Chinese, Jinyu [cjy], Chinese, Mandarin [cmn], Chinese Pidgin English [cpi], Chinese, Pu-Xian [cpx], Chinese Sign Language [csl], Chinese, Huizhou [czh], Chinese, Min Zhong [czo], Chinese, Gan [gan] | 2.18 s | 5.02 s
| mandarin | Chinese, Mandarin [cmn] | Chinese, Mandarin [cmn] | 2.36 s | 4.98 s
| oirot [in middle of alternate names list] | Altai, Southern [alt] | Altai, Southern [alt] | 2.68 s | 4.61 s
| papua new guinea | | Ghayavi [bmk], Pouye [bye], Maring [mbw], Nabak [naf], Naasioi [nas], Nimi [nis], Iduna [viv], Kaninuwa [wat], Wagawaga [wgb], Wahgi [wgi] | 2.12 s | 4.33 s
| tungusic |  | Even [eve], Evenki [evn], Nanai [gld], Manchu [mnc], Negidal [neg], Orok [oaa], Oroch [oac], Oroqen [orh], Xibe [sjo], Udihe [ude] | 2.18 s | 6.50 s
| mongolian [also a writing system] | Buriat, China [bxu], Buriat, Mongolia [bxm], Buriat, Russia [bxr], Mongolian, Halh [khk], Mongolian Sign Language [msr], Mongolian, Peripheral [mvf], Kalmyk-Oirat [xal] | Altai, Southern [alt], Buriat, Mongolia [bxm], Buriat, Russia [bxr], Buriat, China [bxu], Daur [dta], Mongolian, Halh [khk], Manchu [mnc], Mongolian Sign Language [msr], Mongolian, Peripheral [mvf], Xibe [sjo] | 1.87 s | 4.92 s
| pamp1244 [a glottocode] | | Atta, Pamplona [att] | 2.34 s | 1.72 s
| aaa | Ghotuo [aaa], Caac [msq] | Ghotuo [aaa] | 1.90 s | 2.79 s
| asu [an iso code and also the name of two languages] | Asu [asa], Asmat, Casuarina Coast [asc], Asurini, Tocantins [asu], Asoa [asv], Asurini of Xingú [asn], Asuri [asr], Ipulo [ass], Asumboa [aua], Asu [aum] | Asu [asa], Asurini, Tocantins [asu], Asu [aum] | 1.96 s | 2.01 s
| apurinã | Apurinã [apu] | Apurinã [apu] | 2.26 s | 5.22 s