### PR TITLE
Fix: ssh-agent action version v0.9 → v0.9.1

### DIFF
--- a/.github/workflows/backup-prod-db.yml
+++ b/.github/workflows/backup-prod-db.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get install -y rsync
 
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -32,7 +32,7 @@ jobs:
         run: sudo apt-get install -y rsync
 
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/sync-prod-to-staging.yml
+++ b/.github/workflows/sync-prod-to-staging.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9
+        uses: webfactory/ssh-agent@v0.9.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
## Summary
`webfactory/ssh-agent@v0.9` does not exist as a tag — the correct tag is `v0.9.1`. Fixes the staging deploy failure introduced in #423.

## Test plan
- [ ] Merge to `staging` and confirm deploy workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)