### PR TITLE
Phase 4: PHPStan type-safety analysis

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,21 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint:js
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Install PHP dependencies
+        run: composer install --no-progress
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ node_modules/
 # Composer
 vendor/
 
+# PHPUnit
+.phpunit.result.cache
+
 # Misc
 .ftpquota
 ggstemp.html

--- a/.rsync-filter
+++ b/.rsync-filter
@@ -14,6 +14,8 @@
 - phpcs.xml
 - phpunit.xml.dist
 - tests/
+- phpstan.neon
+- phpstan-baseline.neon
 - eslint.config.js
 - .editorconfig
 - .npmrc

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,15 @@
     "wp-coding-standards/wpcs": "^3.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "phpunit/phpunit": "^9.6",
-    "10up/wp_mock": "^1.0"
+    "10up/wp_mock": "^1.0",
+    "phpstan/phpstan": "^1.0",
+    "szepeviktor/phpstan-wordpress": "^1.0"
   },
   "scripts": {
     "lint": "phpcs",
     "lint:fix": "phpcbf",
-    "test": "phpunit"
+    "test": "phpunit",
+    "analyse": "phpstan analyse --memory-limit=-1"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "166394554591586c844d44642561c111",
+    "content-hash": "9293246b0c990b78c50f1a3dd4e4044e",
     "packages": [],
     "packages-dev": [
         {
@@ -646,6 +646,58 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+            },
+            "time": "2026-02-03T19:29:21+00:00"
+        },
+        {
             "name": "phpcsstandards/phpcsextra",
             "version": "1.5.0",
             "source": {
@@ -819,6 +871,59 @@
                 }
             ],
             "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.32",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-30T10:16:31+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2339,6 +2444,149 @@
                 }
             ],
             "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.33.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.10.31",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+            },
+            "time": "2024-06-28T22:27:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,871 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/helpers.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$args$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/queries.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$iso_code$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/queries.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-careers.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 6
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-fellows.php
+
+		-
+			message: "#^Variable \\$atts might not be defined\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-fellows.php
+
+		-
+			message: "#^Variable \\$output might not be defined\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-fellows.php
+
+		-
+			message: "#^Variable \\$output_name might not be defined\\.$#"
+			count: 3
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-fellows.php
+
+		-
+			message: "#^Variable \\$title might not be defined\\.$#"
+			count: 3
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-fellows.php
+
+		-
+			message: "#^Variable \\$title might not be defined\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-languages.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 4
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-lexicons.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 5
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-resources.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-videos.php
+
+		-
+			message: "#^Variable \\$title might not be defined\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/includes/templates/gallery-videos.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 6
+			path: wp-content/plugins/wt-gallery/wt-gallery.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: wp-content/plugins/wt-gallery/wt-gallery.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/events-page.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function get_row_layout not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function reset_rows not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/faq-page.php
+
+		-
+			message: "#^Function the_field not found\\.$#"
+			count: 5
+			path: wp-content/themes/blankslate-child/footer.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/header.php
+
+		-
+			message: "#^Function the_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/header.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 5
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/documents.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/fellows.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/languages.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_html expects string, int\\<0, max\\> given\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/languages.php
+
+		-
+			message: "#^Undefined variable\\: \\$partner_link$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/partners.php
+
+		-
+			message: "#^Undefined variable\\: \\$partner_logo$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/partners.php
+
+		-
+			message: "#^Undefined variable\\: \\$partner_name$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/partners.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/videos.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with int\\<0, max\\> will always evaluate to false\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^Call to static method add_command\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^Call to static method error\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^Call to static method success\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^Function update_field not found\\.$#"
+			count: 4
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^is_wp_error\\(int\\<0, max\\>\\) will always evaluate to false\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/custom-post-types/wp-cli-import.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 10
+			path: wp-content/themes/blankslate-child/includes/document-download-handler.php
+
+		-
+			message: "#^Parameter \\#1 \\$text of function esc_attr expects string, int given\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/document-download-handler.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/events-filter.php
+
+		-
+			message: "#^Call to function is_wp_error\\(\\) with int\\<0, max\\> will always evaluate to false\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^Call to static method add_command\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^Call to static method error\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^Call to static method success\\(\\) on an unknown class WP_CLI\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^Function update_field not found\\.$#"
+			count: 4
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^is_wp_error\\(int\\<0, max\\>\\) will always evaluate to false\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/import-captions.php
+
+		-
+			message: "#^Function acf_maybe_get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/post-object-helpers.php
+
+		-
+			message: "#^Function update_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/post-object-helpers.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/includes/router.php
+
+		-
+			message: "#^Parameter \\#1 \\$search of function str_replace expects array\\|string, int given\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/includes/template-helpers.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/modules/banners/banner--alert.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/banners/banner--main.php
+
+		-
+			message: "#^Variable \\$file_cta might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/banners/banner--main.php
+
+		-
+			message: "#^Variable \\$file_field might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/banners/banner--main.php
+
+		-
+			message: "#^Variable \\$page_banner might not be defined\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/modules/banners/banner--main.php
+
+		-
+			message: "#^Variable \\$team_banner might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/banners/banner--team.php
+
+		-
+			message: "#^Variable \\$wide_button_link might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/button--wide.php
+
+		-
+			message: "#^Variable \\$wide_button_text might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/button--wide.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 6
+			path: wp-content/themes/blankslate-child/modules/carousel--testimonial.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/carousel--testimonial.php
+
+		-
+			message: "#^Function get_row_layout not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/editorial-content.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/editorial-content.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/editorial-content.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/editorial-content.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$category_names might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$fellow_language might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$fellow_name might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$fellow_year might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$page_banner might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$revitalization_fellows_url might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Variable \\$social_links might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/banner-layout.php
+
+		-
+			message: "#^Offset 'banner_copy' does not exist on array\\{banner_header\\: mixed\\}\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/banner-layout.php
+
+		-
+			message: "#^Variable \\$term might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/banner-layout.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/flexible-content/block-layout.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 10
+			path: wp-content/themes/blankslate-child/modules/flexible-content/block-layout.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/block-layout.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/block-layout.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 6
+			path: wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
+
+		-
+			message: "#^Variable \\$post_ids might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/flexible-content/link-group-layout.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/flexible-content/link-group-layout.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/flexible-content/link-group-layout.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 4
+			path: wp-content/themes/blankslate-child/modules/flexible-content/text-layout.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/flexible-content/video-layout.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 11
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^Variable \\$standard_name might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+
+		-
+			message: "#^Variable \\$standard_name might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__fellows.php
+
+		-
+			message: "#^Variable \\$language might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__lexicons.php
+
+		-
+			message: "#^Variable \\$standard_name might not be defined\\.$#"
+			count: 5
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__lexicons.php
+
+		-
+			message: "#^Variable \\$language might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__resources.php
+
+		-
+			message: "#^Variable \\$standard_name might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__resources.php
+
+		-
+			message: "#^Variable \\$standard_name might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/main-content--archive-success.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/main-content--archive-success.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/main-content--archive-success.php
+
+		-
+			message: "#^Variable \\$donation_link might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/main-content--giving-campaign.php
+
+		-
+			message: "#^Variable \\$progress_bar might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/main-content--giving-campaign.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 4
+			path: wp-content/themes/blankslate-child/modules/newsletter.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 8
+			path: wp-content/themes/blankslate-child/modules/page--head.php
+
+		-
+			message: "#^Variable \\$wp might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/page--head.php
+
+		-
+			message: "#^Function the_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/search/search-results.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 6
+			path: wp-content/themes/blankslate-child/modules/search/search-results__thumbnail.php
+
+		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/search/search-results__thumbnail.php
+
+		-
+			message: "#^Variable \\$thumbnail_cta_text might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/search/search-results__thumbnail.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 9
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Function have_rows not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Function the_row not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Parameter \\#1 \\(void\\) of echo cannot be converted to string\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Result of function the_title \\(void\\) is used\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/single-reports__preview.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/social-proof.php
+
+		-
+			message: "#^Variable \\$name might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--grid.php
+
+		-
+			message: "#^Variable \\$profile_picture might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/team/team-member--grid.php
+
+		-
+			message: "#^Variable \\$social_links might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--grid.php
+
+		-
+			message: "#^Variable \\$title might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--grid.php
+
+		-
+			message: "#^Variable \\$name might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--partner.php
+
+		-
+			message: "#^Variable \\$partner_bio might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--partner.php
+
+		-
+			message: "#^Variable \\$partner_email might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--partner.php
+
+		-
+			message: "#^Variable \\$partner_logo might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/team/team-member--partner.php
+
+		-
+			message: "#^Variable \\$partner_website might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--partner.php
+
+		-
+			message: "#^Function the_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$bio might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$name might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$personal_languages might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$profile_picture might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$social_links might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Variable \\$title might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/team/team-member--wide.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/main-content--videos-single.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 8
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$dropbox_link might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$featured_languages might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$public_status might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$video_license might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$video_license_url might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$wikimedia_commons_link might not be defined\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+
+		-
+			message: "#^Variable \\$dropbox_link might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Variable \\$dropbox_link_raw might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Variable \\$public_status might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Variable \\$video_thumbnail might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Variable \\$youtube_id might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Variable \\$youtube_link might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/modules/videos/videos-single--embed.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/single-careers.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 9
+			path: wp-content/themes/blankslate-child/single-documents.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 16
+			path: wp-content/themes/blankslate-child/single-fellows.php
+
+		-
+			message: "#^Variable \\$wp might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/single-fellows.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 2
+			path: wp-content/themes/blankslate-child/single-languages.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 12
+			path: wp-content/themes/blankslate-child/single-videos.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 15
+			path: wp-content/themes/blankslate-child/template-about-board.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 6
+			path: wp-content/themes/blankslate-child/template-about-partners.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 27
+			path: wp-content/themes/blankslate-child/template-about-staff.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-archive-success.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/template-careers.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 4
+			path: wp-content/themes/blankslate-child/template-giving-campaign-24.php
+
+		-
+			message: "#^Function get_sub_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-giving-campaign-24.php
+
+		-
+			message: "#^Variable \\$post_ids might not be defined\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-giving-campaign-24.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/template-giving-campaign.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 3
+			path: wp-content/themes/blankslate-child/template-redirect.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-revitalization-application.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-revitalization-fellows.php
+
+		-
+			message: "#^Function get_field_object not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/template-revitalization-fellows.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,16 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - wp-content/themes/blankslate-child
+        - wp-content/plugins/wt-gallery
+        - wp-content/plugins/typeahead/typeahead.php
+        - tests
+    excludePaths:
+        - */vendor/*
+        - */node_modules/*
+        - wp-content/themes/blankslate-child/acf-json
+        - wp-content/plugins/typeahead/build

--- a/plan.md
+++ b/plan.md
@@ -5,6 +5,13 @@ Items are grouped by area and roughly ordered by priority within each group.
 
 ---
 
+## Manual entry
+* I'd like to dockerize this project for ease of contributor setup
+* I'd like to check/cleanup stale branches
+
+Projects that have been started but not finished:
+* Donors post type
+
 ## Code Quality
 
 ### Refactor dynamic IN clause in `wt-gallery` to eliminate raw SQL


### PR DESCRIPTION
## Summary
- Adds PHPStan (level 5) with `szepeviktor/phpstan-wordpress` stubs for WordPress-aware type analysis
- Generates a **baseline of 426 pre-existing violations** so CI passes from day one; new violations fail the build going forward
- Adds a `phpstan` job to the lint CI workflow alongside PHPCS and ESLint

## Files changed
| File | Change |
|---|---|
| `composer.json` | Add `phpstan/phpstan` + `szepeviktor/phpstan-wordpress`; add `analyse` script |
| `composer.lock` | Updated lock file |
| `phpstan.neon` | Level 5 config; scopes themes, plugins, tests; excludes vendor/build |
| `phpstan-baseline.neon` | Generated baseline (426 existing errors suppressed) |
| `.github/workflows/lint.yml` | New `phpstan` CI job |
| `.rsync-filter` | Exclude PHPStan files from production deploys |

## Test plan
- [ ] `composer analyse` → exits 0 locally
- [ ] `composer lint` → exits 0 (PHPCS unaffected)
- [ ] `composer test` → 23/23 green (PHPUnit unaffected)
- [ ] All CI jobs pass (PHPCS, PHPStan, PHPUnit, ESLint)
- [ ] `phpstan-baseline.neon` is non-empty — confirms PHPStan is doing real work

🤖 Generated with [Claude Code](https://claude.com/claude-code)