### PR TITLE
Refactor featured_languages: remove raw SQL, extract testable function, add 10 unit tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: wp-content/plugins/wt-gallery/includes/helpers.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$args$#"
-			count: 1
-			path: wp-content/plugins/wt-gallery/includes/queries.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$iso_code$#"
 			count: 1
 			path: wp-content/plugins/wt-gallery/includes/queries.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -802,7 +802,7 @@ parameters:
 
 		-
 			message: "#^Function get_field not found\\.$#"
-			count: 12
+			count: 11
 			path: wp-content/themes/blankslate-child/single-videos.php
 
 		-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,3 +9,4 @@ require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/import-c
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/acf-helpers.php';
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/search-filter.php';
 require_once __DIR__ . '/../wp-content/plugins/wt-gallery/includes/render_gallery_items.php';
+require_once __DIR__ . '/../wp-content/plugins/wt-gallery/includes/queries.php';

--- a/tests/unit/GalleryQueryArgsTest.php
+++ b/tests/unit/GalleryQueryArgsTest.php
@@ -1,0 +1,200 @@
+<?php
+use WP_Mock\Tools\TestCase;
+
+class GalleryQueryArgsTest extends TestCase {
+
+	/**
+	 * Returns a full atts array with defaults, merged with any overrides.
+	 *
+	 * @param array $overrides Key/value pairs to override.
+	 * @return array
+	 */
+	private function base_atts( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'post_status'    => 'publish',
+				'post_type'      => 'videos',
+				'posts_per_page' => 6,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+				'meta_key'       => '',
+				'meta_value'     => '',
+				'paged'          => 1,
+				'taxonomy'       => '',
+				'term'           => '',
+				'exclude_self'   => 'false',
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Mocks wp_parse_args to return the given array unchanged.
+	 *
+	 * @param array $atts The merged atts array to return.
+	 * @return void
+	 */
+	private function mock_wp_parse_args( array $atts ): void {
+		WP_Mock::userFunction( 'wp_parse_args', array( 'return' => $atts ) );
+	}
+
+	public function test_featured_languages_single_id_builds_like_meta_query() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'featured_languages',
+				'meta_value' => '42',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args       = build_gallery_query_args( $atts );
+		$meta_query = $args['meta_query'];
+
+		$this->assertSame( 'OR', $meta_query['relation'] );
+		$this->assertCount( 2, $meta_query ); // relation + 1 clause
+		$this->assertSame( 'featured_languages', $meta_query[0]['key'] );
+		$this->assertSame( '"42"', $meta_query[0]['value'] );
+		$this->assertSame( 'LIKE', $meta_query[0]['compare'] );
+	}
+
+	public function test_featured_languages_multiple_ids_build_or_meta_query() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'featured_languages',
+				'meta_value' => '42, 99',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args       = build_gallery_query_args( $atts );
+		$meta_query = $args['meta_query'];
+
+		$this->assertSame( 'OR', $meta_query['relation'] );
+		$this->assertCount( 3, $meta_query ); // relation + 2 clauses
+		$this->assertSame( '"42"', $meta_query[0]['value'] );
+		$this->assertSame( '"99"', $meta_query[1]['value'] );
+	}
+
+	public function test_featured_languages_id_is_cast_to_int() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'featured_languages',
+				'meta_value' => '42abc',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertSame( '"42"', $args['meta_query'][0]['value'] );
+	}
+
+	public function test_fellow_language_wraps_ids_in_quotes() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'fellow_language',
+				'meta_value' => '7, 8',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args    = build_gallery_query_args( $atts );
+		$clauses = array_filter( $args['meta_query'], 'is_array' );
+		$values  = array_column( $clauses, 'value' );
+
+		$this->assertContains( '"7"', $values );
+		$this->assertContains( '"8"', $values );
+	}
+
+	public function test_nations_of_origin_uses_equals_compare() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'nations_of_origin',
+				'meta_value' => 'Nigeria',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertSame( '=', $args['meta_query'][0]['compare'] );
+	}
+
+	public function test_generic_meta_key_multiple_values_build_or_meta_query() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'fellow_year',
+				'meta_value' => '2022, 2023',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args       = build_gallery_query_args( $atts );
+		$meta_query = $args['meta_query'];
+
+		$this->assertSame( 'OR', $meta_query['relation'] );
+		$this->assertCount( 2, array_filter( $meta_query, 'is_array' ) );
+	}
+
+	public function test_tax_query_single_term_builds_correct_structure() {
+		$atts = $this->base_atts(
+			array(
+				'taxonomy' => 'fellow-category',
+				'term'     => 'revitalization',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertSame( 'fellow-category', $args['tax_query'][0]['taxonomy'] );
+		$this->assertSame( 'slug', $args['tax_query'][0]['field'] );
+		$this->assertSame( 'revitalization', $args['tax_query'][0]['terms'] );
+	}
+
+	public function test_tax_query_comma_separated_terms_build_or_query() {
+		$atts = $this->base_atts(
+			array(
+				'taxonomy' => 'fellow-category',
+				'term'     => 'revitalization, preservation',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertSame( 'OR', $args['tax_query']['relation'] );
+		$this->assertCount( 2, array_filter( $args['tax_query'], 'is_array' ) );
+	}
+
+	public function test_exclude_self_adds_post_not_in_for_matching_post_type() {
+		$atts = $this->base_atts(
+			array(
+				'post_type'    => 'videos',
+				'exclude_self' => 'true',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction( 'get_the_ID', array( 'return' => 123 ) );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertSame( array( 123 ), $args['post__not_in'] );
+	}
+
+	public function test_exclude_self_skipped_when_post_type_differs() {
+		$atts = $this->base_atts(
+			array(
+				'post_type'    => 'videos',
+				'exclude_self' => 'true',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'languages' ) );
+
+		$args = build_gallery_query_args( $atts );
+
+		$this->assertArrayNotHasKey( 'post__not_in', $args );
+	}
+}

--- a/wp-content/plugins/wt-gallery/includes/queries.php
+++ b/wp-content/plugins/wt-gallery/includes/queries.php
@@ -27,42 +27,17 @@ function get_custom_gallery_query( $atts = array() ) {
 
 	if ( ! empty( $atts['meta_key'] ) && ! empty( $atts['meta_value'] ) ) {
 		$val_array = array_map( 'trim', explode( ',', $atts['meta_value'] ) );
-		// Special handling for featured_languages
+		// Special handling for featured_languages: meta_value contains language post IDs.
 		if ( $atts['meta_key'] === 'featured_languages' ) {
-			global $wpdb;
-			$placeholders = implode( ',', array_fill( 0, count( $val_array ), '%s' ) );
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- $placeholders contains only %s tokens from array_fill(), not user input.
-			$language_posts = $wpdb->get_col(
-				$wpdb->prepare(
-					"
-                SELECT ID FROM $wpdb->posts
-                WHERE post_type = 'languages'
-                AND post_status = 'publish'
-                AND post_title IN ($placeholders)
-            ",
-					$val_array
-				)
-			);
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-
-			if ( ! empty( $language_posts ) ) {
-				// Step 2: Query videos by these IDs
-				$meta_query = array( 'relation' => 'OR' );
-
-				foreach ( $language_posts as $language_id ) {
-					$meta_query[] = array(
-						'key'     => 'featured_languages',
-						'value'   => '"' . $language_id . '"',
-						'compare' => 'LIKE',
-					);
-				}
-
-				$args['meta_query'] = $meta_query;
-
-			} else {
-				// Force empty result if no language posts found
-				return new WP_Query( array( 'post__in' => array( 0 ) ) );
+			$meta_query = array( 'relation' => 'OR' );
+			foreach ( $val_array as $language_id ) {
+				$meta_query[] = array(
+					'key'     => 'featured_languages',
+					'value'   => '"' . intval( $language_id ) . '"',
+					'compare' => 'LIKE',
+				);
 			}
+			$args['meta_query'] = $meta_query;
 		} else {
 			// Non-featured_languages keys follow original logic
 			$compare_operator = 'LIKE';

--- a/wp-content/plugins/wt-gallery/includes/queries.php
+++ b/wp-content/plugins/wt-gallery/includes/queries.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Retrieves a list of posts for the custom gallery.
+ * Builds the WP_Query args array for the custom gallery.
  *
- * @param array $args Arguments to customize the WP_Query.
- * @return WP_Query The query result.
+ * Contains all arg-building logic for get_custom_gallery_query() so it can
+ * be tested independently of WP_Query instantiation.
+ *
+ * @param array $atts Shortcode/function attributes.
+ * @return array WP_Query arguments.
  */
-
-function get_custom_gallery_query( $atts = array() ) {
+function build_gallery_query_args( $atts = array() ) {
 	$defaults = array(
 		'post_status'    => 'publish',
 		'post_type'      => 'languages', // videos, languages, fellows
@@ -79,7 +81,6 @@ function get_custom_gallery_query( $atts = array() ) {
 				'terms'    => $atts['term'],
 			),
 		);
-
 	}
 
 	// Exclude current post from the query
@@ -90,7 +91,6 @@ function get_custom_gallery_query( $atts = array() ) {
 		}
 	}
 
-	$query = new WP_Query( $args );
 	if ( ! empty( $args['tax_query'] ) ) {
 		$tax_query = $args['tax_query'][0];
 		$terms     = explode( ',', $tax_query['terms'] );
@@ -112,9 +112,17 @@ function get_custom_gallery_query( $atts = array() ) {
 		}
 	}
 
-	$query = new WP_Query( $args );
-	// log_data($query);
-	return $query;
+	return $args;
+}
+
+/**
+ * Retrieves a list of posts for the custom gallery.
+ *
+ * @param array $atts Arguments to customize the WP_Query.
+ * @return WP_Query The query result.
+ */
+function get_custom_gallery_query( $atts = array() ) {
+	return new WP_Query( build_gallery_query_args( $atts ) );
 }
 
 

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
@@ -19,7 +19,7 @@
 			'order'          => 'asc',
 			'pagination'     => 'true',
 			'meta_key'       => 'featured_languages',
-			'meta_value'     => get_the_title(),
+			'meta_value'     => get_the_ID(),
 			'selected_posts' => '',
 			'display_blank'  => 'true',
 			'exclude_self'   => 'true',

--- a/wp-content/themes/blankslate-child/single-videos.php
+++ b/wp-content/themes/blankslate-child/single-videos.php
@@ -17,7 +17,7 @@ if ( is_array( $license_link ) ) {
 $featured_languages = get_field( 'featured_languages' );
 
 $language_names_array = array();
-$iso_codes_array      = array();
+$language_ids_array   = array();
 $language_names       = '';
 
 // ====================
@@ -34,17 +34,14 @@ get_header();
 if ( $featured_languages && is_array( $featured_languages ) ) {
 	foreach ( $featured_languages as $language_post ) {
 		$standard_name = get_field( 'standard_name', $language_post->ID );
-		$iso_code      = get_field( 'iso_code', $language_post->ID );
 		if ( $standard_name ) {
 			$language_names_array[] = $standard_name;
 		}
-		if ( $iso_code ) {
-			$iso_codes_array[] = $iso_code;
-		}
+		$language_ids_array[] = $language_post->ID;
 	}
 }
 
-$iso_codes_string = implode( ', ', $iso_codes_array );
+$language_ids_string = implode( ', ', $language_ids_array );
 
 if ( ! empty( $language_names_array ) ) {
 	$last_name = array_pop( $language_names_array );
@@ -86,7 +83,7 @@ echo '<main class="wt_single-videos__content">';
 		'order'          => 'asc',
 		'pagination'     => 'false',
 		'meta_key'       => 'featured_languages',
-		'meta_value'     => $iso_codes_string,
+		'meta_value'     => $language_ids_string,
 		'selected_posts' => '',
 		'display_blank'  => 'false',
 		'exclude_self'   => 'true',


### PR DESCRIPTION
 ## Summary
  - Removes the raw `$wpdb->prepare()` SQL query from `get_custom_gallery_query()` and replaces it with
  direct use of language post IDs passed by the callers
  - Fixes a broken caller (`single-videos.php` was passing ISO codes to a query that matched on
  `post_title` — those galleries silently returned nothing)
  - Extracts `build_gallery_query_args()` so the arg-building logic is unit-testable without a database
  - Adds 10 new unit tests; test suite grows from 23 to 33

  ## Files changed
  | File | Change |
  |---|---|
  | `queries.php` | Remove raw SQL; extract `build_gallery_query_args()`; fix stale docblock; remove
  dead `WP_Query` call |
  | `single-languages__videos.php` | Pass `get_the_ID()` instead of `get_the_title()` |
  | `single-videos.php` | Collect language post IDs instead of ISO codes |
  | `GalleryQueryArgsTest.php` | 10 new tests |
  | `tests/bootstrap.php` | Load `queries.php` |
  | `phpstan-baseline.neon` | Regenerated (424 errors, down from 426) |

  ## Test plan
  - [x] `composer test` → 33/33 green
  - [x] `composer lint` → clean
  - [x] `composer analyse` → clean
  - [x] On staging: language page videos section shows correct videos
  - [x] On staging: video page "Other videos of..." gallery shows correct videos (was broken before —
  ISO codes never matched post titles)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)