### PR TITLE
Add unit tests for getDomainFromUrl, get_environment, format_event_date_with_proximity

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,3 +10,14 @@ require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/acf-help
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/search-filter.php';
 require_once __DIR__ . '/../wp-content/plugins/wt-gallery/includes/render_gallery_items.php';
 require_once __DIR__ . '/../wp-content/plugins/wt-gallery/includes/queries.php';
+require_once __DIR__ . '/../wp-content/plugins/wt-gallery/includes/helpers.php';
+require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/template-helpers.php';
+
+// events-filter.php calls get_current_datetime() → wp_date() at file scope,
+// before WP_Mock has stubbed it. Define a shim so the include doesn't fatal.
+if ( ! function_exists( 'wp_date' ) ) {
+	function wp_date( $format, $timestamp = null ) {
+		return gmdate( $format, $timestamp ?? time() );
+	}
+}
+require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/events-filter.php';

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -1,0 +1,38 @@
+<?php
+use WP_Mock\Tools\TestCase;
+
+class EnvironmentTest extends TestCase {
+
+	/** @var string */
+	private $original_http_host = '';
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->original_http_host = $_SERVER['HTTP_HOST'] ?? '';
+	}
+
+	public function tearDown(): void {
+		$_SERVER['HTTP_HOST'] = $this->original_http_host;
+		parent::tearDown();
+	}
+
+	public function test_returns_localhost_for_localhost_host() {
+		$_SERVER['HTTP_HOST'] = 'localhost';
+		$this->assertSame( 'localhost', get_environment() );
+	}
+
+	public function test_returns_localhost_for_localhost_with_port() {
+		$_SERVER['HTTP_HOST'] = 'localhost:8888';
+		$this->assertSame( 'localhost', get_environment() );
+	}
+
+	public function test_returns_staging_for_staging_host() {
+		$_SERVER['HTTP_HOST'] = 'staging.wikitongues.org';
+		$this->assertSame( 'staging', get_environment() );
+	}
+
+	public function test_returns_empty_string_for_production() {
+		$_SERVER['HTTP_HOST'] = 'wikitongues.org';
+		$this->assertSame( '', get_environment() );
+	}
+}

--- a/tests/unit/EventDateProximityTest.php
+++ b/tests/unit/EventDateProximityTest.php
@@ -1,0 +1,48 @@
+<?php
+use WP_Mock\Tools\TestCase;
+
+class EventDateProximityTest extends TestCase {
+
+	public function test_far_future_date_has_no_proximity_prefix() {
+		$result = format_event_date_with_proximity( '2090-06-15 10:00:00' );
+
+		$this->assertStringNotContainsString( 'Next', $result );
+		$this->assertStringNotContainsString( 'Last', $result );
+		$this->assertStringNotContainsString( 'Today', $result );
+	}
+
+	public function test_far_past_date_has_no_proximity_prefix() {
+		$result = format_event_date_with_proximity( '2000-01-01 10:00:00' );
+
+		$this->assertStringNotContainsString( 'Next', $result );
+		$this->assertStringNotContainsString( 'Last', $result );
+		$this->assertStringNotContainsString( 'Today', $result );
+	}
+
+	public function test_date_three_days_from_now_has_next_prefix() {
+		$date   = gmdate( 'Y-m-d', strtotime( '+3 days' ) ) . ' 12:00:00';
+		$result = format_event_date_with_proximity( $date );
+
+		$this->assertStringContainsString( 'Next', $result );
+	}
+
+	public function test_date_three_days_ago_has_last_prefix() {
+		$date   = gmdate( 'Y-m-d', strtotime( '-3 days' ) ) . ' 12:00:00';
+		$result = format_event_date_with_proximity( $date );
+
+		$this->assertStringContainsString( 'Last', $result );
+	}
+
+	public function test_today_has_today_prefix() {
+		$date   = gmdate( 'Y-m-d' ) . ' 12:00:00';
+		$result = format_event_date_with_proximity( $date );
+
+		$this->assertStringContainsString( 'Today', $result );
+	}
+
+	public function test_output_contains_formatted_gmdate() {
+		$result = format_event_date_with_proximity( '2090-06-15 10:00:00' );
+
+		$this->assertStringContainsString( '15 June 2090', $result );
+	}
+}

--- a/tests/unit/GetDomainFromUrlTest.php
+++ b/tests/unit/GetDomainFromUrlTest.php
@@ -1,0 +1,25 @@
+<?php
+use WP_Mock\Tools\TestCase;
+
+class GetDomainFromUrlTest extends TestCase {
+
+	public function test_strips_www_prefix() {
+		$this->assertSame( 'example.com', getDomainFromUrl( 'https://www.example.com/path' ) );
+	}
+
+	public function test_returns_host_without_www_unchanged() {
+		$this->assertSame( 'example.com', getDomainFromUrl( 'https://example.com/page' ) );
+	}
+
+	public function test_preserves_non_www_subdomain() {
+		$this->assertSame( 'blog.example.com', getDomainFromUrl( 'https://blog.example.com/post' ) );
+	}
+
+	public function test_ignores_path_and_query_string() {
+		$this->assertSame( 'example.com', getDomainFromUrl( 'https://example.com/a/b?q=1#anchor' ) );
+	}
+
+	public function test_works_without_path() {
+		$this->assertSame( 'example.com', getDomainFromUrl( 'https://www.example.com' ) );
+	}
+}


### PR DESCRIPTION
These three functions had pure PHP logic with no database dependency — the remaining low-hanging fruit before the DB-dependent ceiling that Phase 5 unlocks.

- GetDomainFromUrlTest (5 tests): www stripping, subdomain preservation, path/query ignored, no-path URL
- EnvironmentTest (4 tests): localhost, localhost+port, staging host, production host; setUp/tearDown restore $_SERVER['HTTP_HOST']
- EventDateProximityTest (6 tests): far future/past (no prefix), ±3 days (Next/Last prefix), today, output format; uses gmdate()+noon time to avoid midnight edge cases in %a day counting

bootstrap.php: load helpers.php, template-helpers.php, events-filter.php; add wp_date() shim (events-filter.php calls it at file scope before WP_Mock stubs are active)

Test suite: 33 → 48 tests, 61 → 80 assertions. PHPCS and PHPStan clean.