### PR TITLE
Restructure plan.md with ToC checklist and add plan-archive.md

### DIFF
--- a/plan-archive.md
+++ b/plan-archive.md
@@ -1,0 +1,121 @@
+# Wikitongues – Completed Work
+
+Completed items from [plan.md](plan.md), in reverse chronological order.
+Each entry includes branch, PR, merge commit, and a summary of what was done.
+
+---
+
+## 2026-02-19
+
+### Low-hanging unit tests
+**Branch:** `feature/cc/unit-tests-low-hanging`
+**PR:** [#441](https://github.com/wikitongues/wikitongues.org/pull/441)
+**Merged:** `aff4d8d` — 2026-02-19
+
+Added unit tests for three pure-logic functions that needed no DB:
+- `getDomainFromUrl()` in `wt-gallery/helpers.php` — 5 tests (www stripping, subdomain preservation, path/query ignored)
+- `get_environment()` in `template-helpers.php` — 4 tests (sets/restores `$_SERVER['HTTP_HOST']`)
+- `format_event_date_with_proximity()` in `events-filter.php` — 6 tests (far future/past, ±3 days, today, output format)
+
+Notes: `setUp()`/`tearDown()` must be `public` in `WP_Mock\Tools\TestCase` subclasses. Added `wp_date()` bootstrap shim to handle `events-filter.php`'s file-scope `get_current_datetime()` call before WP_Mock is active. Fixed PHPCS `date()` → `gmdate()` violations throughout.
+
+---
+
+### Raw SQL refactor — `wt-gallery` featured languages
+**Branch:** `fix/cc/raw-sql-featured-languages`
+**PR:** [#438](https://github.com/wikitongues/wikitongues.org/pull/438)
+**Merged:** `3996593` — 2026-02-19
+
+Removed the `$wpdb->prepare()` raw SQL block from `get_custom_gallery_query()` in `queries.php`. The `featured_languages` branch was building a dynamic `IN ($placeholders)` clause by looking up language post IDs from `post_title` — an unsafe and brittle approach requiring a `phpcs:disable` suppression.
+
+Changes:
+- **`queries.php`:** Removed 35-line raw SQL block; `featured_languages` branch now treats `meta_value` as comma-separated post IDs directly (9 lines). Extracted `build_gallery_query_args($atts)` as a pure testable function; `get_custom_gallery_query()` reduced to one line. Removed a dead first `new WP_Query()` call whose result was discarded. Fixed stale `@param $args` docblock.
+- **`single-languages__videos.php`:** `'meta_value' => get_the_title()` → `get_the_ID()`
+- **`single-videos.php`:** Changed from passing ISO codes (broken — they were matched against `post_title`) to passing language post IDs directly. Fixed a silent bug where video galleries on language pages always returned empty results.
+- **`tests/unit/GalleryQueryArgsTest.php`:** 10 new unit tests covering all `meta_key` branches of `build_gallery_query_args()`.
+
+---
+
+### PHPStan static analysis (Phase 4)
+**Branch:** `feature/cc/phase-4-phpstan`
+**PR:** [#435](https://github.com/wikitongues/wikitongues.org/pull/435)
+**Merged:** `29151f8` — 2026-02-19
+
+Added PHPStan level 5 type-safety analysis with WordPress stubs.
+
+Changes:
+- **`composer.json`:** Added `phpstan/phpstan ^1.0` and `szepeviktor/phpstan-wordpress ^1.0` to `require-dev`; added `"analyse"` script with `--memory-limit=-1` (child processes crash at PHP's default 128M)
+- **`phpstan.neon`:** New config — level 5, paths cover theme + wt-gallery plugin + typeahead.php + tests; includes WordPress extension and baseline
+- **`phpstan-baseline.neon`:** Generated baseline of 424 pre-existing violations; CI fails only on new errors introduced after baseline
+- **`.github/workflows/lint.yml`:** Added `phpstan` job after `lint-js`
+- **`.rsync-filter`:** Excluded `phpstan.neon` and `phpstan-baseline.neon` from deploy sync
+
+Notes: baseline regeneration required temporarily removing the baseline include from `phpstan.neon`, running `composer analyse --generate-baseline`, then re-adding it. Required after any refactor that changes violation count.
+
+---
+
+### Unit testing infrastructure (Phase 3)
+**Branch:** `feature/cc/phase-3-unit-tests`
+**PR:** [#432](https://github.com/wikitongues/wikitongues.org/pull/432)
+**Merged:** `93c0fff` — 2026-02-19
+
+Established PHPUnit + WP_Mock testing infrastructure and wrote the first batch of unit tests.
+
+Setup:
+- PHPUnit 9.6 + WP_Mock 1.1 (`require-dev`); `composer test` script; `phpunit.xml.dist`
+- `tests/bootstrap.php` — WP_Mock init, requires for all testable includes, support class includes
+- `tests/` and `phpunit.xml.dist` excluded from rsync (`.rsync-filter`); `tests/` added to PHPCS scope
+- `.github/workflows/test.yml` — PHPUnit job on every PR
+
+Tests written (initial batch):
+- `safe_dropbox_url()`, `get_safe_value()` — `import-captions.php`
+- `wt_meta_value()` — `acf-helpers.php`
+- `searchfilter()` regex routing — `search-filter.php`
+- `generate_gallery_pagination()` — `render_gallery_items.php`
+
+Notes: WP_Mock 1.x is locked to PHPUnit ^9.6 due to Patchwork incompatibility with PHPUnit 10+. Upgrade path: push WP API calls to function edges, reducing mocking surface, then drop WP_Mock incrementally. See plan.md Layer 2 for full constraint details.
+
+---
+
+### Static analysis — PHPCS + ESLint (Phase 2)
+**Branch:** `feature/cc/phase-2-code-quality`
+**PR:** [#428](https://github.com/wikitongues/wikitongues.org/pull/428)
+**Merged:** `6887458` — 2026-02-19
+
+Added PHPCS with WordPress Coding Standards and ESLint to CI.
+
+- **`composer.json`:** Added `squizlabs/php_codesniffer`, `wp-coding-standards/wpcs`, `phpcsstandards/phpcsutils` to `require-dev`; added `"lint"` script
+- **`.phpcs.xml`:** Config covering theme and wt-gallery plugin with WPCS ruleset
+- **`.github/workflows/lint.yml`:** `lint-php` and `lint-js` jobs on every PR
+
+---
+
+### CI and deployment pipeline (Phase 1)
+**Branch:** `feature/cc/phase-1-operational`
+**PR:** [#423](https://github.com/wikitongues/wikitongues.org/pull/423)
+**Merged:** `9361c5f` — 2026-02-19
+
+Established the foundational CI/CD pipeline: GitHub Actions workflows, rsync-based deployment to staging and production, `.rsync-filter` exclusion rules, and baseline project hygiene (`.gitignore`, `composer.json` platform pinning to PHP 8.2 for CI compatibility).
+
+---
+
+### CI fix — SSH agent version
+**Branch:** `fix/cc/ssh-agent-version`
+**PR:** [#425](https://github.com/wikitongues/wikitongues.org/pull/425)
+**Merged:** `b9be0b4` — 2026-02-19
+
+Minor fix to SSH agent action version in deployment workflow.
+
+---
+
+## 2026-02 (data fix, no PR)
+
+### w-prefixed language ID routing — wblu/blu collision
+**Type:** Production data fix
+**Date:** 2026-02-20
+
+**Root cause:** 19 language posts had `post_title` values that collided with existing ISO codes. For example, the Bildts language (`post_name = wblu`) had `post_title = 'blu'` and ACF fields set to `blu` values, causing `/languages/wblu` to render content for Hmong Njua instead of Bildts. WordPress was routing to the correct post by slug, but all displayed content belonged to the wrong language.
+
+**Fix:** Direct data correction on production — titles, iso_code, standard_name, and related ACF fields updated for all 19 affected posts. Database pulled from production to staging and local.
+
+**Prevention:** Layer 5 — Data Integrity (see plan.md) will catch duplicate iso_codes and standard_names on a weekly schedule before they cause routing failures.

--- a/plan.md
+++ b/plan.md
@@ -2,58 +2,79 @@
 
 This file tracks known issues, deferred refactors, and planned improvements.
 Items are grouped by area and roughly ordered by priority within each group.
+Completed work is documented in [plan-archive.md](plan-archive.md).
 
 ---
 
-## Manual entry
-* I'd like to dockerize this project for ease of contributor setup
-* I'd like to check/cleanup stale branches
+## Table of Contents
 
-Projects that have been started but not finished:
-* Donors post type
+- **[Backlog](#backlog)**
+  - [x] Convert plan.md to checklist format
+  - [ ] Dockerize project
+  - [ ] Audit and clean up stale branches
+  - [ ] Airtable reconciliation (520+ records missing fields)
+  - [x] Fix w-prefixed language routing — wblu/blu ([archive](plan-archive.md))
+  - [ ] Complete Donors post type
+
+- **[Code Quality](#code-quality)**
+  - [x] Refactor raw SQL in `wt-gallery` ([archive](plan-archive.md))
+
+- **[Plugins](#plugins)**
+  - [ ] Track `wt-form` in version control
+  - [ ] Track `integromat-connector` in version control
+
+- **[Infrastructure](#infrastructure)**
+  - [ ] Migrate from Stylus
+
+- **[Testing Strategy](#testing-strategy)**
+  - [x] Layer 1 — Static Analysis, Phase 2 ([archive](plan-archive.md))
+    - [x] PHPStan, Phase 4 ([archive](plan-archive.md))
+  - [x] Layer 2 — Unit Tests, Phase 3 ([archive](plan-archive.md))
+  - [ ] Layer 3 — Integration Tests, Phase 5
+  - [ ] Layer 4 — End-to-End & Visual Regression, Phase 6
+  - [ ] Layer 5 — Data Integrity, Phase 7
+  - **[Security](#security)**
+    - [x] PHPCS security sniffs ([archive](plan-archive.md))
+    - [ ] WPScan in CI
+    - [ ] Secrets scanning
+    - [ ] Security review of `wt-form` and `integromat-connector`
+
+---
+
+## Backlog
+
+- [ ] **Dockerize project** for ease of contributor setup
+- [ ] **Audit and clean up stale branches**
+- [ ] **Airtable reconciliation** — 520+ language records missing essential fields. make.com syncs from Airtable without field guarantees; records arrive in WordPress incomplete. Rather than enforcing hard requirements at the WordPress layer, reconciliation should happen at the Airtable source: institute field requirements there and handle any divergence before sync.
+- [ ] **Complete Donors post type** (in progress, stalled)
+
+---
 
 ## Code Quality
 
-### Refactor dynamic IN clause in `wt-gallery` to eliminate raw SQL
-**File:** `wp-content/plugins/wt-gallery/includes/queries.php` (~line 33–44)
-**Context:** The `featured_languages` branch of `get_custom_gallery_query()` builds a
-dynamic `IN ($placeholders)` clause using `array_fill('%s')` and `$wpdb->prepare()`.
-This is the correct WordPress pattern, but PHPCS cannot statically verify that
-`$placeholders` is safe, requiring a `phpcs:disable` suppression comment.
-**Goal:** Refactor to avoid raw SQL entirely — query by post ID or slug instead of
-`post_title`, which would allow `WP_Query` args (`post__in`) to replace the manual
-`$wpdb` query. This also makes the query more robust (post titles are not unique).
-**Prerequisite:** Understand how gallery shortcode callers pass `meta_value` for
-`featured_languages` — the refactor must preserve that interface or update callers too.
+_All items complete. See [plan-archive.md](plan-archive.md)._
 
 ---
 
 ## Plugins
 
-### Track `wt-form` in version control when feature work resumes
-**File:** `wp-content/plugins/wt-form/`
-**Context:** Currently excluded from git. Plugin handles form submissions to Airtable
-and Mailchimp. Not actively used; excluded from linting scope for now.
-**Goal:** Add to `.gitignore` allowlist, include in PHPCS scan, and review for
-security (form validation, API key handling).
+- [ ] **Track `wt-form` in version control** when feature work resumes
+  **File:** `wp-content/plugins/wt-form/`
+  Currently excluded from git. Plugin handles form submissions to Airtable and Mailchimp. Not actively used; excluded from linting scope for now.
+  **Goal:** Add to `.gitignore` allowlist, include in PHPCS scan, review security (form validation, API key handling).
 
-### Track `integromat-connector` in version control when automation work resumes
-**File:** `wp-content/plugins/integromat-connector/`
-**Context:** Currently excluded from git. Custom Make.com connector with API token
-auth. Not in active development; excluded from linting scope for now.
-**Goal:** Add to `.gitignore` allowlist, include in PHPCS scan, review API token
-handling and REST endpoint security.
+- [ ] **Track `integromat-connector` in version control** when automation work resumes
+  **File:** `wp-content/plugins/integromat-connector/`
+  Currently excluded from git. Custom Make.com connector with API token auth. Not in active development; excluded from linting scope for now.
+  **Goal:** Add to `.gitignore` allowlist, include in PHPCS scan, review API token handling and REST endpoint security.
 
 ---
 
 ## Infrastructure
 
-### Migrate from Stylus to a maintained CSS preprocessor
-**Context:** Stylus is largely unmaintained. Its dependency chain (`glob@7` →
-`minimatch@3`) has known ReDoS vulnerabilities (dev-only, no production impact).
-`npm audit` flags 3 high-severity findings with no clean in-place fix.
-**Goal:** Migrate to PostCSS or Sass. Resolves audit findings and improves long-term
-maintainability of the CSS build pipeline.
+- [ ] **Migrate from Stylus to a maintained CSS preprocessor** (PostCSS or Sass)
+  Stylus is largely unmaintained. Its dependency chain (`glob@7` → `minimatch@3`) has known ReDoS vulnerabilities (dev-only, no production impact). `npm audit` flags 3 high-severity findings with no clean in-place fix.
+  **Goal:** Migrate to PostCSS or Sass. Resolves audit findings and improves long-term maintainability of the CSS build pipeline.
 
 ---
 
@@ -69,26 +90,30 @@ Coverage is built in layers, from fast/cheap to slow/comprehensive. Each phase d
 **Catches:** coding standards violations, basic security anti-patterns (unescaped output, direct DB queries), JS style issues
 **Runs:** on every PR via GitHub Actions
 
-**Gap — PHPStan (Phase 4)**
-Type-safety analysis: undefined variables, wrong argument types, unreachable code, method calls on null.
-Complements PHPCS (style/security) with correctness guarantees.
-Requires a PHPStan config + WordPress stubs (`szepeviktor/phpstan-wordpress`).
+**PHPStan ✅ (Phase 4, complete)**
+Type-safety analysis at level 5 with `szepeviktor/phpstan-wordpress` stubs. Baseline of
+pre-existing violations in `phpstan-baseline.neon`; CI fails only on new violations.
+Runs on every PR via GitHub Actions alongside PHPCS.
 
 ---
 
-### Layer 2 — Unit Tests (Phase 3, complete)
+### Layer 2 — Unit Tests ✅ (Phase 3, complete)
 **Tools:** PHPUnit 9.6 + WP_Mock 1.1
 **Catches:** regressions in isolated business logic — URL encoding, meta value fallbacks, search routing regex, pagination math
 **Runs:** on every PR via GitHub Actions
 **Does not cover:** templates, DB queries, actual rendering, hook/filter wiring
 
-**Scope (initial):** functions in `includes/` that have testable logic without a database:
-- `import-captions.php` → `safe_dropbox_url()`, `get_safe_value()` (pure PHP, no mocks)
-- `acf-helpers.php` → `wt_meta_value()` (mock `esc_attr`)
-- `search-filter.php` → `searchfilter()` regex routing (mock `is_admin`, `get_query_var`, query stub)
-- `render_gallery_items.php` → `generate_gallery_pagination()` (mock `esc_attr`, stdClass query stub)
+**Covered functions:**
+- `import-captions.php` → `safe_dropbox_url()`, `get_safe_value()`
+- `acf-helpers.php` → `wt_meta_value()`
+- `search-filter.php` → `searchfilter()` regex routing
+- `render_gallery_items.php` → `generate_gallery_pagination()`
+- `wt-gallery/helpers.php` → `getDomainFromUrl()`
+- `template-helpers.php` → `get_environment()`
+- `events-filter.php` → `format_event_date_with_proximity()`
+- `wt-gallery/includes/queries.php` → `build_gallery_query_args()` (10 tests)
 
-**Expand over time:** `getDomainFromUrl()` in `wt-gallery/helpers.php`, `get_environment()` and date logic in `template-helpers.php`, `format_event_date_with_proximity()` in `events-filter.php` once extracted. Any new function with non-trivial logic should ship with a unit test.
+**Expand over time:** any new function with non-trivial logic should ship with a unit test.
 
 **Known constraints and upgrade path:**
 WP_Mock 1.x uses [Patchwork](https://github.com/antecedent/patchwork) to redefine global PHP functions at runtime, which is fundamentally at odds with how PHPUnit 10+ works internally. As a result, the entire WordPress unit testing ecosystem (WP_Mock, Brain Monkey) is locked to PHPUnit ^9.6, which is in maintenance mode (security fixes only). PHPUnit 9.6 will reach end-of-life; PHPUnit 10+ is the present and future of PHP testing.
@@ -121,8 +146,31 @@ As functions are refactored to be purer, WP_Mock can be removed from individual 
 
 ---
 
-### Security (ongoing)
-- PHPCS security sniffs already run (Layer 1)
-- **Gap:** WPScan in CI — checks installed plugins/themes against known CVE database
-- **Gap:** secrets scanning — ensure API keys, tokens never land in git history
-- `wt-form` and `integromat-connector` plugins need security review when brought into version control (see Plugins section below)
+### Layer 5 — Data Integrity (Phase 7, future)
+**Tools:** WP-CLI custom command, server cron or GitHub Actions scheduled workflow
+**Catches:** duplicate iso_codes/standard_names (root cause of the wblu/blu routing bug), missing required ACF fields, slug/iso_code mismatches, records that would cause routing or display failures
+**Runs:** weekly scheduled job; logs results; reports violations (log file + optional GitHub issue or admin notice)
+**Does not replace:** Airtable reconciliation (see Backlog) — complements it by catching problems that slip through to WordPress
+
+**Priority checks:**
+- No two published language posts share the same `iso_code` ACF value
+- No two published language posts share the same `standard_name` / `post_title`
+- No published language post has a blank `iso_code`
+- `post_name` (URL slug) matches `iso_code` for all published language posts — mismatch causes silent routing failures like the wblu/blu bug
+- (Future) Cross-check against Airtable API: every WordPress language record has a corresponding Airtable record
+
+**Implementation approach:**
+- WP-CLI command (`wp wt integrity check`) registered in a new `includes/cli/` file in the theme
+- Command queries the DB directly via `$wpdb`, outputs a structured report (pass/fail per check, count of violations, sample offending records)
+- Server cron runs weekly: `wp wt integrity check >> /path/to/integrity.log 2>&1`
+- GitHub Actions `schedule` workflow (weekly) can SSH to staging and run the command, posting results as a job summary
+- Violations do not block deploys — this is a monitoring/alerting layer, not a gate
+
+---
+
+### Security
+
+- [x] **PHPCS security sniffs** — runs on every PR via Layer 1
+- [ ] **WPScan in CI** — check installed plugins/themes against known CVE database
+- [ ] **Secrets scanning** — ensure API keys and tokens never land in git history
+- [ ] **Security review of `wt-form` and `integromat-connector`** — when brought into version control (see Plugins)

--- a/wp-content/themes/blankslate-child/stylus/require/language-index.styl
+++ b/wp-content/themes/blankslate-child/stylus/require/language-index.styl
@@ -56,12 +56,13 @@
 		scroll-margin-top 162px
 
 	.language-columns
-		$gutter = 8px
+		$gutter = 4px
 		$columns = 5
 		display grid
 		flex-wrap wrap
 		grid-template-columns repeat(auto-fill, minmax((($content - ($gutter * $columns)) / $columns), 1fr))
 		column-gap $gutter
+		row-gap $gutter
 
 	.language-item
 		text--body($blue())
@@ -70,6 +71,7 @@
 		text-decoration none
 		display flex
 		position relative
+		border 1px solid #fef8dd
 
 		*
 			float left
@@ -91,6 +93,7 @@
 
 		&:hover
 			background $blue(10)
+			border-color $blue(12)
 
 		span
 			margin-right 1rem


### PR DESCRIPTION
## Summary
- Converts `plan.md` to a checklist format with a table of contents at the top mirroring section structure; completed items marked `[x]` with links to archive
- Moves completed one-off work out of detail sections (backlog, code quality) into the new `plan-archive.md`
- Adds `plan-archive.md` — changelog-style file documenting Phases 1–4, raw SQL refactor, low-hanging unit tests, and wblu data fix, each with branch, PR number, merge commit, and summary
- Adds Layer 5 — Data Integrity to the testing strategy (weekly WP-CLI integrity checks for duplicate iso_codes, slug mismatches, missing required fields)

## Test plan
- [ ] Review `plan.md` ToC — all items render as checkboxes, completed items link to archive
- [ ] Review `plan-archive.md` — entries for all completed phases with accurate PR numbers and dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)