### PR TITLE
Fix territories: generalise wt_prefix_the() across all templates

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -722,7 +722,7 @@ parameters:
 
 		-
 			message: "#^Variable \\$current_region might not be defined\\.$#"
-			count: 5
+			count: 3
 			path: wp-content/themes/blankslate-child/modules/territories/territories-active-region.php
 
 		-
@@ -738,11 +738,6 @@ parameters:
 		-
 			message: "#^Variable \\$current_region might not be defined\\.$#"
 			count: 3
-			path: wp-content/themes/blankslate-child/modules/territories/territories-child-regions.php
-
-		-
-			message: "#^Variable \\$territory might not be defined\\.$#"
-			count: 1
 			path: wp-content/themes/blankslate-child/modules/territories/territories-child-regions.php
 
 		-

--- a/plan.md
+++ b/plan.md
@@ -15,6 +15,7 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
   - [ ] Airtable reconciliation (520+ records missing fields)
   - [x] Fix w-prefixed language routing — wblu/blu ([archive](plan-archive.md))
   - [ ] Complete Donors post type
+  - [ ] Link Fellows to Territories and vice versa
 - [ ] Migrate `nations_of_origin` on language posts from text → territories relationship field — intentionally deferred; `Also spoken in` (the `territories` ACF relationship field) serves as the linked alternative in the sidebar. Migration requires changing the ACF field type, updating the make.com sync, and backfilling data.
 
 - **[Code Quality](#code-quality)**
@@ -26,6 +27,7 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
 
 - **[Infrastructure](#infrastructure)**
   - [ ] Migrate from Stylus
+  - [ ] Replace Font Awesome
   - [ ] Performance profiling and monitoring
 
 - **[Testing Strategy](#testing-strategy)**
@@ -49,6 +51,9 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
 - [ ] **Audit and clean up stale branches**
 - [ ] **Airtable reconciliation** — 520+ language records missing essential fields. make.com syncs from Airtable without field guarantees; records arrive in WordPress incomplete. Rather than enforcing hard requirements at the WordPress layer, reconciliation should happen at the Airtable source: institute field requirements there and handle any divergence before sync.
 - [ ] **Complete Donors post type** (in progress, stalled)
+- [ ] **Link Fellows to Territories and vice versa**
+  Fellows posts should display the territory they are associated with. Territory pages should display a gallery of Fellows from that territory.
+  **Goal:** Add a territory relationship field to Fellows posts (or derive it from existing data); render the territory link on single-fellow pages; add a Fellows gallery block to `single-territories.php`.
 
 ---
 
@@ -77,6 +82,10 @@ _All items complete. See [plan-archive.md](plan-archive.md)._
 - [ ] **Migrate from Stylus to a maintained CSS preprocessor** (PostCSS or Sass)
   Stylus is largely unmaintained. Its dependency chain (`glob@7` → `minimatch@3`) has known ReDoS vulnerabilities (dev-only, no production impact). `npm audit` flags 3 high-severity findings with no clean in-place fix.
   **Goal:** Migrate to PostCSS or Sass. Resolves audit findings and improves long-term maintainability of the CSS build pipeline.
+
+- [ ] **Replace Font Awesome**
+  Font Awesome is loaded as an external dependency (CDN or npm package). It adds weight to every page load for a relatively small set of icons actually used. Replacing with inline SVGs or a purpose-built icon set (e.g. Heroicons, Phosphor) would reduce load time and remove the external CDN dependency.
+  **Goal:** Audit which FA icons are in use, replace with lightweight inline SVGs or a self-hosted sprite, remove the FA dependency entirely.
 
 - [ ] **Performance profiling and monitoring**
   No visibility into page load times or query performance in production. Known risk areas already identified: territory pages with large language counts (India: 403 languages, China: 249, Brazil: 200, USA: 197) and continent-level region pages aggregating many territories. `get_field()` returning full post objects on relationship fields at scale is the primary pattern to watch.

--- a/wp-content/themes/blankslate-child/includes/template-helpers.php
+++ b/wp-content/themes/blankslate-child/includes/template-helpers.php
@@ -75,3 +75,14 @@ function html5wp_pagination() {
 		)
 	);
 }
+
+/**
+ * Prefix a territory or region name with "The" where grammatically required.
+ *
+ * @param string $name Territory or region name.
+ * @return string Name with "The " prepended if applicable.
+ */
+function wt_prefix_the( string $name ): string {
+	$prefixed_names = array( 'Americas', 'Caribbean', 'Sahel', 'Gambia', 'Bahamas' );
+	return in_array( $name, $prefixed_names, true ) ? 'the ' . $name : $name;
+}

--- a/wp-content/themes/blankslate-child/modules/territories/territories-active-region.php
+++ b/wp-content/themes/blankslate-child/modules/territories/territories-active-region.php
@@ -15,7 +15,7 @@
 			),
 		)
 	);
-	$current_region_name = in_array( $current_region->name, array( 'Americas', 'Caribbean', 'Sahel', 'Gambia' ), true ) ? 'The ' . $current_region->name : $current_region->name;
+	$current_region_name = wt_prefix_the( $current_region->name );
 	?>
 	<h1><?php echo $territory; ?></h1>
 	<?php	if ( $territory_query->have_posts() ) : ?>
@@ -26,7 +26,7 @@
 			while ( $territory_query->have_posts() ) :
 				$territory_query->the_post();
 				$territory_name       = $territory_query->post->post_title;
-				$territory_name_clean = in_array( $territory_name, array( 'Americas', 'Caribbean', 'Sahel', 'Gambia' ), true ) ? 'The ' . $territory_name : $territory_name;
+				$territory_name_clean = wt_prefix_the( $territory_name );
 				if ( $territory_query->post->ID === $territory_id ) {
 					continue;
 				}

--- a/wp-content/themes/blankslate-child/modules/territories/territories-child-regions.php
+++ b/wp-content/themes/blankslate-child/modules/territories/territories-child-regions.php
@@ -15,17 +15,15 @@
 			),
 		)
 	);
-	// $current_region_name = in_array($current_region->name, ['Americas', 'Caribbean', 'Sahel', 'Gambia']) ? 'The ' . $current_region->name : $current_region->name;
 	?>
-	<!-- <h1><?php echo $territory; ?></h1> -->
 	<?php	if ( $territory_query->have_posts() ) : ?>
 	<section class="related-territories metadata">
-		<strong>Territories in <a href="<?php echo esc_url( get_term_link( $current_region ) ); ?>"><?php echo esc_html( $current_region->name ); ?></a></strong>
+		<strong>Territories in <a href="<?php echo esc_url( get_term_link( $current_region ) ); ?>"><?php echo esc_html( wt_prefix_the( $current_region->name ) ); ?></a></strong>
 		<ul>
 			<?php
 			while ( $territory_query->have_posts() ) :
 				$territory_query->the_post();
-				$territory_name = in_array( get_the_title(), array( 'Americas', 'Caribbean', 'Sahel', 'Gambia' ), true ) ? 'The ' . get_the_title() : get_the_title();
+				$territory_name = wt_prefix_the( get_the_title() );
 				// if ( $territory_query->post->ID == $territory_id ) continue;
 				echo '<li><a href="' . esc_url( get_permalink() ) . '">' . esc_html( $territory_name ) . '</a></li>';
 			endwhile;

--- a/wp-content/themes/blankslate-child/modules/territories/territories-parent-regions.php
+++ b/wp-content/themes/blankslate-child/modules/territories/territories-parent-regions.php
@@ -18,7 +18,8 @@
 			if ( $parent->term_id === $current_parent_id ) {
 				continue;
 			}
-			echo '<li><a href="' . esc_url( get_term_link( $parent ) ) . '">' . esc_html( $parent->name ) . '</a></li>';
+				$parent_name = wt_prefix_the( $parent->name );
+			echo '<li><a href="' . esc_url( get_term_link( $parent ) ) . '">' . esc_html( $parent_name ) . '</a></li>';
 		}
 		?>
 		</ul>

--- a/wp-content/themes/blankslate-child/modules/territories/territories-sibling-regions.php
+++ b/wp-content/themes/blankslate-child/modules/territories/territories-sibling-regions.php
@@ -8,7 +8,7 @@
 			'orderby'    => 'slug',
 		)
 	);
-	$parent_name     = get_term( $current_parent_id )->name;
+	$parent_name     = wt_prefix_the( get_term( $current_parent_id )->name );
 	$parent_link     = get_term_link( $current_parent_id );
 	if ( ! is_wp_error( $sibling_regions ) && ! empty( $sibling_regions ) ) : ?>
 		<section class="sibling-regions metadata">
@@ -19,7 +19,7 @@
 			if ( $sibling->term_id === $current_region->term_id ) {
 				continue;
 			}
-				$sibling_name = in_array( $sibling->name, array( 'Americas', 'Caribbean', 'Sahel', 'Gambia' ), true ) ? 'The ' . $sibling->name : $sibling->name;
+				$sibling_name = wt_prefix_the( $sibling->name );
 				echo '<li><a href="' . esc_url( get_term_link( $sibling ) ) . '">' . esc_html( $sibling_name ) . '</a></li>';
 		}
 		?>

--- a/wp-content/themes/blankslate-child/single-territories.php
+++ b/wp-content/themes/blankslate-child/single-territories.php
@@ -2,7 +2,7 @@
 	$territory_id = get_the_ID();
 
 	get_header();
-	$territory = get_the_title();
+	$territory = wt_prefix_the( get_the_title() );
 
 	echo '<div class="wt_meta--territories-single">';
 	require 'modules/territories/meta--territories-single.php';

--- a/wp-content/themes/blankslate-child/stylus/require/meta--languages-single.styl
+++ b/wp-content/themes/blankslate-child/stylus/require/meta--languages-single.styl
@@ -8,6 +8,7 @@
 	h1
 		margin-bottom 3rem
 		text--header($black)
+		text-transform capitalize
 
 	.metadata
 		padding 16px 0
@@ -54,6 +55,9 @@
 		li
 			margin-bottom 1.2rem
 
+			a
+				text-transform capitalize
+
 			&:last-of-type
 				margin-bottom 0
 
@@ -72,6 +76,7 @@
 		text-decoration none
 		display block
 		line-height 1.6
+
 
 		&:hover
 			text-decoration underline

--- a/wp-content/themes/blankslate-child/taxonomy-region.php
+++ b/wp-content/themes/blankslate-child/taxonomy-region.php
@@ -4,7 +4,7 @@ get_header();
 // Grab the current region term.
 $current_region    = get_queried_object();
 $current_parent_id = $current_region->parent ?: $current_region->term_id;
-$territory         = $current_region->name;
+$territory         = wt_prefix_the( $current_region->name );
 $is_continent      = ( 0 === $current_region->parent );
 
 // On continent pages, expand the query to include all child sub-region terms


### PR DESCRIPTION
## Summary

- Centralise the \"the Americas / the Bahamas / etc.\" prefix logic into a single `wt_prefix_the()` helper in `template-helpers.php`; previously the same `in_array` check was duplicated 4–5 times with inconsistent name lists and capitalisation
- Apply `wt_prefix_the()` in `single-territories.php` — fixes h1 and gallery title not showing prefix (e.g. \"Bahamas\" → \"the Bahamas\")
- Apply in `taxonomy-region.php` — fixes region page h1
- Apply in all four territory sidebar modules (`territories-active-region`, `territories-child-regions`, `territories-parent-regions`, `territories-sibling-regions`)
- CSS: add `text-transform: capitalize` to territory h1 and sidebar list links so lowercase \"the\" prefix renders correctly at display layer
- `plan.md`: add Replace Font Awesome and Fellows↔Territories backlog items

## Test plan

- [ ] Visit a territory page for \"the Bahamas\" — h1 and gallery title should read \"the Bahamas\" (capitalised by CSS)
- [ ] Visit a region page for \"the Americas\" — h1 should show \"the Americas\"
- [ ] Visit any territory with no prefix (e.g. Uganda) — name unchanged
- [ ] Sidebar modules (sibling regions, parent regions, child regions) show correct prefix where applicable
- [ ] `composer lint` passes
- [ ] `composer test` — 48/48 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)