### PR TITLE
Fix: render multiple territories as comma-separated links

### DIFF
--- a/wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
+++ b/wp-content/themes/blankslate-child/modules/fellows/meta--fellows-single.php
@@ -73,10 +73,12 @@ function generate_language_links( $fellow_language ) {
 			<section class="info">
 				<?php
 				if ( $fellow_territory ) {
-					$territories = is_array( $fellow_territory ) ? $fellow_territory : array( $fellow_territory );
+					$territories     = is_array( $fellow_territory ) ? $fellow_territory : array( $fellow_territory );
+					$territory_links = array();
 					foreach ( $territories as $terr ) {
-						echo '<p class="fellow-territory"><a href="' . esc_url( get_permalink( $terr->ID ) ) . '">' . esc_html( wt_prefix_the( $terr->post_title ) ) . '</a></p>';
+						$territory_links[] = '<a href="' . esc_url( get_permalink( $terr->ID ) ) . '">' . esc_html( wt_prefix_the( $terr->post_title ) ) . '</a>';
 					}
+					echo '<p class="fellow-territory">' . implode( ', ', $territory_links ) . '</p>';
 				}
 				echo '<p>' . esc_html( $page_banner['banner_copy'] ) . '</p>';
 				echo '<p class="categories">' . $category_names . '</p>';


### PR DESCRIPTION
## Summary

When a fellow is associated with more than one territory, the sidebar previously rendered a separate `<p class="fellow-territory">` per territory. This changes it to a single `<p>` with comma-separated `<a>` tags:

```html
<p class="fellow-territory">
  <a href=".../peru/">Peru</a>, <a href=".../austria/">Austria</a>
</p>
```

## Test plan

- [ ] Fellow with one territory → single link in one `<p>`, no trailing comma
- [ ] Fellow with two territories → both links comma-separated in one `<p>`
- [ ] Fellow with no territory → section absent
- [ ] `composer lint` → 0 errors
- [ ] `composer test` → 56/56 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)