### PR TITLE
Archive fellows-territories linking and branch audit

### DIFF
--- a/plan-archive.md
+++ b/plan-archive.md
@@ -5,7 +5,40 @@ Each entry includes branch, PR, merge commit, and a summary of what was done.
 
 ---
 
+## 2026-02-21
+
+### Branch audit and cleanup
+**Type:** Maintenance (no PR)
+**Date:** 2026-02-21
+
+Audited all branches not owned by `cc/` automation. Three `_`-prefixed branches remained after all cc/ branches were auto-deleted on PR merge:
+
+- **`_feature/language-search-improvements`** — Orphaned search overlay, never wired up; superseded by `search-filter.php`. Deleted.
+- **`_fix/fix-thumbnails`** — Three files at wrong root-level `modules/` path, superseded by organised subdirectory versions (`modules/search/`, `modules/videos/`). Deleted.
+- **`_hotfix/rclone-cicd-action`** — Kept intentionally for potential future rsync/rclone CI work.
+
+---
+
 ## 2026-02-20
+
+### Fellows ↔ Territories — bidirectional linking
+**Branches:** `feature/cc/fellows-territories-linking`, `fix/fellow-territory-style`, `fix/cc/fellows-territory-comma-separated`
+**PRs:** [#450](https://github.com/wikitongues/wikitongues.org/pull/450), [#451](https://github.com/wikitongues/wikitongues.org/pull/451), [#452](https://github.com/wikitongues/wikitongues.org/pull/452), [#455](https://github.com/wikitongues/wikitongues.org/pull/455)
+**Merged & deployed to production:** 2026-02-20
+
+Added a `fellow_territory` ACF field to Fellows posts and wired up bidirectional display on fellow, territory, region, and continent pages.
+
+Changes:
+- **`acf-json/group_624f529b40c49.json`:** New `post_object` field `fellow_territory` — type `territories`, `multiple: 1`, `allow_null: 1`, `return_format: object`. Editors can associate one or more territories with a fellow.
+- **`single-fellows.php`:** `$fellow_territory = get_field('fellow_territory')` passed into scope for the meta module.
+- **`modules/fellows/meta--fellows-single.php`:** Territory link(s) rendered before `banner_copy` as a single `<p class="fellow-territory">` with comma-separated `<a>` anchors when multiple territories are set. Uses `wt_prefix_the()` for correct display ("the Bahamas", "the Americas").
+- **`single-territories.php`:** Restructured to sidebar + `<main>` layout (matching single-language page). Fellows gallery (3 cols, 6 posts, paginated) appears first, then languages gallery (3 cols, 6 posts, paginated). Fellows pre-queried with `LIKE '"id"'` meta_query to match ACF-serialised multiple post_object values.
+- **`taxonomy-region.php`:** Same layout restructure. Fellows aggregated across all territory IDs in the region via OR LIKE meta_query; languages aggregated via existing `selected_posts`. Applied to both region and continent pages (continent pages already expand child term IDs).
+- **`tests/unit/PrefixTheTest.php`:** 8 unit tests for `wt_prefix_the()` — covers all five prefixed names (Americas, Caribbean, Sahel, Gambia, Bahamas), ordinary names, empty string, and case-sensitivity. Total test count: 56 tests, 89 assertions.
+
+Notes: ACF serialises `post_object` arrays as `a:2:{i:0;s:3:"42";i:1;s:3:"99";}` — integer IDs stored as quoted strings. Meta queries must use `LIKE '"id"'` (not `= id` with `NUMERIC`) to match these values.
+
+---
 
 ### Territories CPT — "the" prefix generalisation
 **Branch:** `fix/cc/territories-prefix-the`

--- a/plan.md
+++ b/plan.md
@@ -11,11 +11,11 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
 - **[Backlog](#backlog)**
   - [x] Convert plan.md to checklist format
   - [ ] Dockerize project
-  - [ ] Audit and clean up stale branches
+  - [x] Audit and clean up stale branches ([archive](plan-archive.md))
   - [ ] Airtable reconciliation (520+ records missing fields)
   - [x] Fix w-prefixed language routing — wblu/blu ([archive](plan-archive.md))
   - [ ] Complete Donors post type
-  - [ ] Link Fellows to Territories and vice versa
+  - [x] Link Fellows to Territories and vice versa ([archive](plan-archive.md))
   - [ ] Maps on territory templates
   - [ ] Gallery `link_out` param — filtered archive pages
 - [ ] Migrate `nations_of_origin` on language posts from text → territories relationship field — intentionally deferred; `Also spoken in` (the `territories` ACF relationship field) serves as the linked alternative in the sidebar. Migration requires changing the ACF field type, updating the make.com sync, and backfilling data.
@@ -50,13 +50,8 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
 ## Backlog
 
 - [ ] **Dockerize project** for ease of contributor setup
-- [ ] **Audit and clean up stale branches**
 - [ ] **Airtable reconciliation** — 520+ language records missing essential fields. make.com syncs from Airtable without field guarantees; records arrive in WordPress incomplete. Rather than enforcing hard requirements at the WordPress layer, reconciliation should happen at the Airtable source: institute field requirements there and handle any divergence before sync.
 - [ ] **Complete Donors post type** (in progress, stalled)
-- [ ] **Link Fellows to Territories and vice versa**
-  Fellows posts should display the territory they are associated with. Territory pages should display a gallery of Fellows from that territory.
-  **Goal:** Add a territory relationship field to Fellows posts (or derive it from existing data); render the territory link on single-fellow pages; add a Fellows gallery block to `single-territories.php`.
-
 - [ ] **Gallery `link_out` param — filtered archive pages**
   Gallery sections (e.g. "Fellows from the United States", "Languages from the United States", "English videos") should be linkable to a dedicated full-page listing showing all matching items with full pagination. Auto-generated — no editor action required.
 
@@ -146,7 +141,7 @@ Runs on every PR via GitHub Actions alongside PHPCS.
 - `search-filter.php` → `searchfilter()` regex routing
 - `render_gallery_items.php` → `generate_gallery_pagination()`
 - `wt-gallery/helpers.php` → `getDomainFromUrl()`
-- `template-helpers.php` → `get_environment()`
+- `template-helpers.php` → `get_environment()`, `wt_prefix_the()`
 - `events-filter.php` → `format_event_date_with_proximity()`
 - `wt-gallery/includes/queries.php` → `build_gallery_query_args()` (10 tests)
 


### PR DESCRIPTION
## Summary
- Marks "Link Fellows to Territories" and "Audit and clean up stale branches" as complete in plan.md ToC
- Removes their backlog body text (moved to archive)
- Adds `wt_prefix_the()` to Layer 2 covered functions list
- plan-archive.md: new entries for Fellows ↔ Territories (#450–455) and the branch audit

## Test plan
- [ ] Verify plan.md ToC shows both items checked
- [ ] Verify plan-archive.md has Fellows ↔ Territories and branch audit entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)