### PR TITLE
Add language metadata archives (linguistic_genealogy + writing_systems)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -93,6 +93,16 @@ parameters:
 		-
 			message: "#^Function get_field not found\\.$#"
 			count: 1
+			path: wp-content/themes/blankslate-child/archive-languages.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
+			path: wp-content/themes/blankslate-child/archive-videos.php
+
+		-
+			message: "#^Function get_field not found\\.$#"
+			count: 1
 			path: wp-content/themes/blankslate-child/events-page.php
 
 		-

--- a/plan.md
+++ b/plan.md
@@ -17,7 +17,7 @@ Completed work is documented in [plan-archive.md](plan-archive.md).
   - [ ] Complete Donors post type
   - [x] Link Fellows to Territories and vice versa ([archive](plan-archive.md))
   - [ ] Maps on territory templates
-  - [ ] Gallery `link_out` param — filtered archive pages
+  - [x] Gallery `link_out` param — filtered archive pages
   - [ ] Download gateway plugin
 - [ ] Migrate `nations_of_origin` on language posts from text → territories relationship field — intentionally deferred; `Also spoken in` (the `territories` ACF relationship field) serves as the linked alternative in the sidebar. Migration requires changing the ACF field type, updating the make.com sync, and backfilling data.
 
@@ -73,12 +73,13 @@ _No prerequisites. Unblocks all credential-sensitive work._
 ### Tier 2 — Plugin hygiene + infrastructure cleanup + quick wins
 _Parallel. Secrets scanning (Tier 1) required before `integromat-connector` enters VCS. `wt-form` deletion has no prerequisites (no live usage, no hardcoded credentials). Stylus, FA, and Donors have no hard deps but must land before the Layer 4 visual baseline (Tier 5)._
 
-- [ ] Delete `wt-form` plugin _(no prerequisites — confirmed unused, credentials in ACF options not in files)_
-- [ ] Track `integromat-connector` in version control
-- [ ] Migrate from Stylus
+- [x] Delete `wt-form` plugin ([archive](plan-archive.md))
+- [x] Audit `integromat-connector` REST API exposure _(findings: no ACF fields opted in; token active; Guard only covers WP core entities — see Plugins section)_
+- [x] Gallery `link_out` param ([archive](plan-archive.md))
+- [x] Gallery `link_out` param — filtered archive pages (`archive-fellows.php`, `archive-languages.php`, `archive-videos.php`; `?territory=` / `?language=` filter params; "see all" button on section header)
 - [ ] Replace Font Awesome
 - [ ] Complete Donors post type
-- [ ] Gallery `link_out` param
+- [ ] Migrate from Stylus
 
 ---
 
@@ -122,7 +123,7 @@ _Maps introduces visual changes to high-traffic territory/region templates; Laye
 - [ ] **Dockerize project** for ease of contributor setup
 - [ ] **Airtable reconciliation** — 520+ language records missing essential fields. make.com syncs from Airtable without field guarantees; records arrive in WordPress incomplete. Rather than enforcing hard requirements at the WordPress layer, reconciliation should happen at the Airtable source: institute field requirements there and handle any divergence before sync.
 - [ ] **Complete Donors post type** (in progress, stalled)
-- [ ] **Gallery `link_out` param — filtered archive pages**
+- [x] **Gallery `link_out` param — filtered archive pages**
   Gallery sections (e.g. "Fellows from the United States", "Languages from the United States", "English videos") should be linkable to a dedicated full-page listing showing all matching items with full pagination. Auto-generated — no editor action required.
 
   **Two parts:**

--- a/tests/unit/GalleryQueryArgsTest.php
+++ b/tests/unit/GalleryQueryArgsTest.php
@@ -120,6 +120,32 @@ class GalleryQueryArgsTest extends TestCase {
 		$this->assertSame( '=', $args['meta_query'][0]['compare'] );
 	}
 
+	public function test_linguistic_genealogy_uses_equals_compare() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'linguistic_genealogy',
+				'meta_value' => 'Indo-European',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$result = build_gallery_query_args( $atts );
+		$this->assertSame( '=', $result['meta_query'][0]['compare'] );
+	}
+
+	public function test_writing_systems_uses_equals_compare() {
+		$atts = $this->base_atts(
+			array(
+				'meta_key'   => 'writing_systems',
+				'meta_value' => 'Latin',
+			)
+		);
+		$this->mock_wp_parse_args( $atts );
+
+		$result = build_gallery_query_args( $atts );
+		$this->assertSame( '=', $result['meta_query'][0]['compare'] );
+	}
+
 	public function test_generic_meta_key_multiple_values_build_or_meta_query() {
 		$atts = $this->base_atts(
 			array(

--- a/wp-content/plugins/wt-gallery/includes/queries.php
+++ b/wp-content/plugins/wt-gallery/includes/queries.php
@@ -45,7 +45,7 @@ function build_gallery_query_args( $atts = array() ) {
 			$compare_operator = 'LIKE';
 			if ( $atts['meta_key'] === 'fellow_language' ) {
 				$val_array = array_map( fn( $v ) => '"' . intval( $v ) . '"', $val_array );
-			} elseif ( $atts['meta_key'] === 'nations_of_origin' ) {
+			} elseif ( in_array( $atts['meta_key'], array( 'nations_of_origin', 'linguistic_genealogy', 'writing_systems' ), true ) ) {
 				$compare_operator = '=';
 			}
 

--- a/wp-content/plugins/wt-gallery/wt-gallery.php
+++ b/wp-content/plugins/wt-gallery/wt-gallery.php
@@ -145,6 +145,7 @@ function create_gallery_instance( $params ) {
 		'exclude_self'   => 'true',
 		'taxonomy'       => '',
 		'term'           => '',
+		'link_out'       => '',
 	);
 
 	$args = wp_parse_args( $params, $defaults );
@@ -168,6 +169,7 @@ function create_gallery_instance( $params ) {
 		'exclude_self="' . $args['exclude_self'] . '" ' .
 		'taxonomy="' . $args['taxonomy'] . '" ' .
 		'term="' . $args['term'] . '" ' .
+		'link_out="' . esc_url( $args['link_out'] ) . '" ' .
 		']'
 	);
 }
@@ -197,6 +199,7 @@ function custom_gallery( $atts ) {
 			'exclude_self'   => 'true', // define whether to show or hide the current post entry string true or false
 			'taxonomy'       => '',
 			'term'           => '',
+			'link_out'       => '',
 		),
 		$atts,
 		'custom_gallery'
@@ -258,7 +261,7 @@ function custom_gallery( $atts ) {
 	$output = '';
 	if ( $query->have_posts() || $atts['display_blank'] === 'true' ) {
 		$output  = '<div class="' . $classes . '">';
-		$output .= $atts['title'] ? '<strong class="wt_sectionHeader">' . $header . '</strong>' : '';
+		$output .= $atts['title'] ? ( $atts['link_out'] ? '<a href="' . esc_url( $atts['link_out'] ) . '" class="wt_sectionHeader">' . $header . '</a>' : '<strong class="wt_sectionHeader">' . $header . '</strong>' ) : '';
 		$output .= $atts['subtitle'] ? '<p class="wt_subtitle">' . $atts['subtitle'] . '</p>' : '';
 		if ( $query->have_posts() ) {
 			$output .= render_gallery_items( $query, $atts, $atts['gallery_id'], $paged, $data_attributes );

--- a/wp-content/plugins/wt-gallery/wt-gallery.php
+++ b/wp-content/plugins/wt-gallery/wt-gallery.php
@@ -253,15 +253,24 @@ function custom_gallery( $atts ) {
 
 	// Labels come from WP post type objects and are already localised at registration; use a
 	// simple conditional rather than _n() to avoid passing dynamic strings to a translation function.
-	$label  = $count === 1 ? $singular : $plural;
-	$header = $atts['show_total'] === 'true'
-	? $atts['title'] . '<span>' . $count . ' ' . $label . '</span>'
-	: $atts['title'];
+	$label   = $count === 1 ? $singular : $plural;
+	$see_all = $atts['link_out'] ? '<a href="' . esc_url( $atts['link_out'] ) . '" class="wt_seeAll">see all</a>' : '';
+
+	if ( $atts['show_total'] === 'true' || $see_all ) {
+		$right = '<span class="wt_sectionHeader-meta">'
+			. ( $atts['show_total'] === 'true' ? '<span>' . $count . ' ' . $label . '</span>' : '' )
+			. $see_all
+			. '</span>';
+	} else {
+		$right = '';
+	}
+
+	$header = $atts['title'] . $right;
 
 	$output = '';
 	if ( $query->have_posts() || $atts['display_blank'] === 'true' ) {
 		$output  = '<div class="' . $classes . '">';
-		$output .= $atts['title'] ? ( $atts['link_out'] ? '<a href="' . esc_url( $atts['link_out'] ) . '" class="wt_sectionHeader">' . $header . '</a>' : '<strong class="wt_sectionHeader">' . $header . '</strong>' ) : '';
+		$output .= $atts['title'] ? '<strong class="wt_sectionHeader">' . $header . '</strong>' : '';
 		$output .= $atts['subtitle'] ? '<p class="wt_subtitle">' . $atts['subtitle'] . '</p>' : '';
 		if ( $query->have_posts() ) {
 			$output .= render_gallery_items( $query, $atts, $atts['gallery_id'], $paged, $data_attributes );

--- a/wp-content/themes/blankslate-child/archive-fellows.php
+++ b/wp-content/themes/blankslate-child/archive-fellows.php
@@ -1,0 +1,94 @@
+<?php
+get_header();
+
+$territory_slug = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
+$territory_post = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
+
+echo '<main class="wt_archive-fellows">';
+
+if ( $territory_post ) {
+	$territory_id   = $territory_post->ID;
+	$territory_name = wt_prefix_the( $territory_post->post_title );
+
+	$fellows_query = new WP_Query(
+		array(
+			'post_type'      => 'fellows',
+			'posts_per_page' => -1,
+			'post_status'    => 'publish',
+			'meta_query'     => array(
+				array(
+					'key'     => 'fellow_territory',
+					'value'   => '"' . intval( $territory_id ) . '"',
+					'compare' => 'LIKE',
+				),
+			),
+		)
+	);
+
+	if ( $fellows_query->have_posts() ) {
+		$fellow_ids = wp_list_pluck( $fellows_query->posts, 'ID' );
+		wp_reset_postdata();
+		$params = array(
+			'title'          => 'Fellows from ' . $territory_name,
+			'subtitle'       => '',
+			'show_total'     => 'true',
+			'post_type'      => 'fellows',
+			'columns'        => 3,
+			'posts_per_page' => 9,
+			'orderby'        => 'title',
+			'order'          => 'asc',
+			'pagination'     => 'true',
+			'meta_key'       => '',
+			'meta_value'     => '',
+			'selected_posts' => implode( ',', $fellow_ids ),
+			'display_blank'  => 'false',
+			'exclude_self'   => 'false',
+			'taxonomy'       => '',
+			'term'           => '',
+		);
+	} else {
+		$params = array(
+			'title'          => 'Fellows from ' . $territory_name,
+			'subtitle'       => '',
+			'show_total'     => 'true',
+			'post_type'      => 'fellows',
+			'columns'        => 3,
+			'posts_per_page' => 9,
+			'orderby'        => 'title',
+			'order'          => 'asc',
+			'pagination'     => 'true',
+			'meta_key'       => '',
+			'meta_value'     => '',
+			'selected_posts' => '-1',
+			'display_blank'  => 'true',
+			'exclude_self'   => 'false',
+			'taxonomy'       => '',
+			'term'           => '',
+		);
+	}
+	echo create_gallery_instance( $params );
+} else {
+	$params = array(
+		'title'          => 'Fellows',
+		'subtitle'       => '',
+		'show_total'     => 'true',
+		'post_type'      => 'fellows',
+		'columns'        => 3,
+		'posts_per_page' => 9,
+		'orderby'        => 'title',
+		'order'          => 'asc',
+		'pagination'     => 'true',
+		'meta_key'       => '',
+		'meta_value'     => '',
+		'selected_posts' => '',
+		'display_blank'  => 'false',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+	echo create_gallery_instance( $params );
+}
+
+echo '</main>';
+require 'modules/newsletter.php';
+get_footer();

--- a/wp-content/themes/blankslate-child/archive-languages.php
+++ b/wp-content/themes/blankslate-child/archive-languages.php
@@ -3,6 +3,8 @@ get_header();
 
 $territory_slug = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
 $territory_post = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
+$genealogy      = isset( $_GET['genealogy'] ) ? sanitize_text_field( wp_unslash( $_GET['genealogy'] ) ) : '';
+$writing_system = isset( $_GET['writing_system'] ) ? sanitize_text_field( wp_unslash( $_GET['writing_system'] ) ) : '';
 
 echo '<main class="wt_archive-languages">';
 
@@ -25,6 +27,44 @@ if ( $territory_post ) {
 		'meta_key'       => '',
 		'meta_value'     => '',
 		'selected_posts' => $selected,
+		'display_blank'  => 'true',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+} elseif ( $genealogy ) {
+	$params = array(
+		'title'          => $genealogy . ' languages',
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'languages',
+		'columns'        => 4,
+		'posts_per_page' => 12,
+		'orderby'        => 'title',
+		'order'          => 'asc',
+		'pagination'     => 'true',
+		'meta_key'       => 'linguistic_genealogy',
+		'meta_value'     => $genealogy,
+		'selected_posts' => '',
+		'display_blank'  => 'true',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+} elseif ( $writing_system ) {
+	$params = array(
+		'title'          => $writing_system . ' languages',
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'languages',
+		'columns'        => 4,
+		'posts_per_page' => 12,
+		'orderby'        => 'title',
+		'order'          => 'asc',
+		'pagination'     => 'true',
+		'meta_key'       => 'writing_systems',
+		'meta_value'     => $writing_system,
+		'selected_posts' => '',
 		'display_blank'  => 'true',
 		'exclude_self'   => 'false',
 		'taxonomy'       => '',

--- a/wp-content/themes/blankslate-child/archive-languages.php
+++ b/wp-content/themes/blankslate-child/archive-languages.php
@@ -1,0 +1,57 @@
+<?php
+get_header();
+
+$territory_slug = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
+$territory_post = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
+
+echo '<main class="wt_archive-languages">';
+
+if ( $territory_post ) {
+	$territory_name = wt_prefix_the( $territory_post->post_title );
+	// false = return raw IDs, not hydrated WP_Post objects (critical for large territories).
+	$language_ids = get_field( 'languages', $territory_post->ID, false );
+	$selected     = $language_ids ? implode( ',', $language_ids ) : '';
+
+	$params = array(
+		'title'          => 'Languages of ' . $territory_name,
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'languages',
+		'columns'        => 4,
+		'posts_per_page' => 12,
+		'orderby'        => 'title',
+		'order'          => 'asc',
+		'pagination'     => 'true',
+		'meta_key'       => '',
+		'meta_value'     => '',
+		'selected_posts' => $selected,
+		'display_blank'  => 'true',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+} else {
+	$params = array(
+		'title'          => 'Languages',
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'languages',
+		'columns'        => 4,
+		'posts_per_page' => 12,
+		'orderby'        => 'title',
+		'order'          => 'asc',
+		'pagination'     => 'true',
+		'meta_key'       => '',
+		'meta_value'     => '',
+		'selected_posts' => '',
+		'display_blank'  => 'false',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+}
+
+echo create_gallery_instance( $params );
+echo '</main>';
+require 'modules/newsletter.php';
+get_footer();

--- a/wp-content/themes/blankslate-child/archive-videos.php
+++ b/wp-content/themes/blankslate-child/archive-videos.php
@@ -1,0 +1,58 @@
+<?php
+get_header();
+
+$language_slug = isset( $_GET['language'] ) ? sanitize_title( wp_unslash( $_GET['language'] ) ) : '';
+$language_post = $language_slug ? get_page_by_path( $language_slug, OBJECT, 'languages' ) : null;
+
+echo '<main class="wt_archive-videos">';
+
+if ( $language_post ) {
+	$standard_name = get_field( 'standard_name', $language_post->ID ) ?: $language_post->post_title;
+	$title_name    = $standard_name;
+	if ( substr( $standard_name, -7 ) !== 'anguage' ) {
+		$title_name .= ' language';
+	}
+
+	$params = array(
+		'title'          => $title_name . ' videos',
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'videos',
+		'columns'        => 3,
+		'posts_per_page' => 9,
+		'orderby'        => 'date',
+		'order'          => 'desc',
+		'pagination'     => 'true',
+		'meta_key'       => 'featured_languages',
+		'meta_value'     => $language_post->ID,
+		'selected_posts' => '',
+		'display_blank'  => 'true',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+} else {
+	$params = array(
+		'title'          => 'Videos',
+		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+		'show_total'     => 'true',
+		'post_type'      => 'videos',
+		'columns'        => 3,
+		'posts_per_page' => 9,
+		'orderby'        => 'date',
+		'order'          => 'desc',
+		'pagination'     => 'true',
+		'meta_key'       => '',
+		'meta_value'     => '',
+		'selected_posts' => '',
+		'display_blank'  => 'false',
+		'exclude_self'   => 'false',
+		'taxonomy'       => '',
+		'term'           => '',
+	);
+}
+
+echo create_gallery_instance( $params );
+echo '</main>';
+require 'modules/newsletter.php';
+get_footer();

--- a/wp-content/themes/blankslate-child/includes/router.php
+++ b/wp-content/themes/blankslate-child/includes/router.php
@@ -7,11 +7,21 @@ function wikitongues_custom_template_redirects() {
 
 	// Archive redirects
 	if ( is_post_type_archive( 'fellows' ) ) {
+		if ( isset( $_GET['territory'] ) ) {
+			return; // Serve archive-fellows.php with territory filter.
+		}
 		wp_redirect( home_url( '/revitalization/fellows', 'relative' ) );
 		exit;
 	}
 
 	if ( is_post_type_archive( array( 'languages', 'videos', 'lexicons', 'resources', 'captions' ) ) ) {
+		if ( is_post_type_archive( 'languages' ) &&
+			( isset( $_GET['territory'] ) || isset( $_GET['genealogy'] ) || isset( $_GET['writing_system'] ) ) ) {
+			return; // Serve archive-languages.php with filter.
+		}
+		if ( is_post_type_archive( 'videos' ) && isset( $_GET['language'] ) ) {
+			return; // Serve archive-videos.php with language filter.
+		}
 		wp_redirect( home_url( '/archive', 'relative' ) );
 		exit;
 	}

--- a/wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+++ b/wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
@@ -114,12 +114,20 @@ if ( have_rows( 'wikipedia_editions' ) ) {
 
 				<?php if ( $writing_systems ) : ?>
 					<strong>Writing systems</strong>
-					<p class="wt_text--label"><?php echo esc_html( $writing_systems ); ?></p>
+					<p class="wt_text--label">
+						<a href="<?php echo esc_url( add_query_arg( 'writing_system', rawurlencode( $writing_systems ), get_post_type_archive_link( 'languages' ) ) ); ?>">
+							<?php echo esc_html( $writing_systems ); ?>
+						</a>
+					</p>
 				<?php endif; ?>
 
 				<?php if ( $linguistic_genealogy ) : ?>
 					<strong>Linguistic genealogy</strong>
-					<p class="wt_text--label"><?php echo esc_html( $linguistic_genealogy ); ?></p>
+					<p class="wt_text--label">
+						<a href="<?php echo esc_url( add_query_arg( 'genealogy', rawurlencode( $linguistic_genealogy ), get_post_type_archive_link( 'languages' ) ) ); ?>">
+							<?php echo esc_html( $linguistic_genealogy ); ?>
+						</a>
+					</p>
 				<?php endif; ?>
 
 				<?php if ( $egids ) : ?>

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
@@ -25,7 +25,7 @@
 			'exclude_self'   => 'true',
 			'taxonomy'       => '',
 			'term'           => '',
-			'link_out'       => home_url( '/videos/?language=' . get_post_field( 'post_name', get_the_ID() ), 'relative' ),
+			'link_out'       => add_query_arg( 'language', get_post_field( 'post_name', get_the_ID() ), get_post_type_archive_link( 'videos' ) ),
 		);
 		echo create_gallery_instance( $params );
 		?>

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
@@ -25,6 +25,7 @@
 			'exclude_self'   => 'true',
 			'taxonomy'       => '',
 			'term'           => '',
+			'link_out'       => home_url( '/videos/?language=' . get_post_field( 'post_name', get_the_ID() ), 'relative' ),
 		);
 		echo create_gallery_instance( $params );
 		?>

--- a/wp-content/themes/blankslate-child/single-territories.php
+++ b/wp-content/themes/blankslate-child/single-territories.php
@@ -47,7 +47,7 @@
 			'exclude_self'   => 'false',
 			'taxonomy'       => '',
 			'term'           => '',
-			'link_out'       => home_url( '/fellows/?territory=' . $territory_slug, 'relative' ),
+			'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'fellows' ) ),
 		);
 		echo create_gallery_instance( $fellows_params );
 	}
@@ -75,7 +75,7 @@
 		'exclude_self'   => 'false',
 		'taxonomy'       => '',
 		'term'           => '',
-		'link_out'       => home_url( '/languages/?territory=' . $territory_slug, 'relative' ),
+		'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'languages' ) ),
 	);
 	echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/single-territories.php
+++ b/wp-content/themes/blankslate-child/single-territories.php
@@ -1,5 +1,6 @@
 <?php
-	$territory_id = get_the_ID();
+	$territory_id   = get_the_ID();
+	$territory_slug = get_post_field( 'post_name', $territory_id );
 
 	get_header();
 	$territory = wt_prefix_the( get_the_title() );
@@ -46,6 +47,7 @@
 			'exclude_self'   => 'false',
 			'taxonomy'       => '',
 			'term'           => '',
+			'link_out'       => home_url( '/fellows/?territory=' . $territory_slug, 'relative' ),
 		);
 		echo create_gallery_instance( $fellows_params );
 	}
@@ -73,6 +75,7 @@
 		'exclude_self'   => 'false',
 		'taxonomy'       => '',
 		'term'           => '',
+		'link_out'       => home_url( '/languages/?territory=' . $territory_slug, 'relative' ),
 	);
 	echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/stylus/require/gallery.styl
+++ b/wp-content/themes/blankslate-child/stylus/require/gallery.styl
@@ -41,6 +41,25 @@ $aspect-ratio = 16/9
 		display flex
 		justify-content space-between
 
+	.wt_sectionHeader-meta
+		display flex
+		align-items baseline
+		gap 8px
+
+	.wt_seeAll
+		font-style normal
+		font-weight normal
+		font-size 1.2rem
+		color $blue()
+		text-decoration none
+		border 1px solid $blue()
+		border-radius 4px
+		padding 2px 8px
+		white-space nowrap
+
+		&:hover
+			background $blue(10)
+
 	.gallery-container
 		margin-bottom 24px
 


### PR DESCRIPTION
## Summary

- **queries.php**: Extends the exact-match (`=`) condition to `linguistic_genealogy` and `writing_systems`, preventing false positives (e.g. a LIKE search for "Indo-European" would also match "Non-Indo-European")
- **archive-languages.php**: Adds `?genealogy=` and `?writing_system=` filter branches — each renders a titled, paginated gallery of languages sharing that metadata value
- **meta--languages-single.php**: Wraps both metadata fields in `<a>` archive links using `get_post_type_archive_link()` + `add_query_arg()`, so clicking a value navigates to the filtered archive
- **GalleryQueryArgsTest.php**: Adds two tests confirming `linguistic_genealogy` and `writing_systems` use exact-match compare

Branches off `feature/cc/gallery-link-out` (PR #462) — includes the routing fix.

## Test plan

- [ ] Language page: click a "Linguistic genealogy" value (e.g. "Indo-European") → `/languages/?genealogy=Indo-European` → gallery titled "Indo-European languages" showing only matching languages
- [ ] Language page: click a "Writing systems" value (e.g. "Latin") → `/languages/?writing_system=Latin` → "Latin languages" gallery
- [ ] `/languages/` with no params → unfiltered gallery (no regression)
- [ ] `/languages/?territory=<slug>` → still works (no regression)
- [ ] `composer lint` → 0 errors; `composer test` → 58 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)