### PR TITLE
Fix archive-menu missing on /videos/?language= archive

### DIFF
--- a/wp-content/themes/blankslate-child/header.php
+++ b/wp-content/themes/blankslate-child/header.php
@@ -131,7 +131,7 @@
 						);
 					} elseif (
 							strpos( $template_slug, 'archive' ) !== false ||
-							is_post_type_archive( array( 'languages', 'fellows', 'territories' ) ) ||
+							is_post_type_archive( array( 'languages', 'videos', 'fellows', 'territories' ) ) ||
 							is_singular( array( 'languages', 'videos', 'territories' ) ) ||
 							is_tax( 'region' ) ||
 							is_search()


### PR DESCRIPTION
## Summary

- Add `videos` to the `is_post_type_archive()` condition in `header.php` so the archive-menu secondary nav appears on `/videos/?language=<slug>` filtered views.

## Test plan

- [ ] `/videos/?language=afr` → archive-menu visible in header
- [ ] `/videos/` (unfiltered) → archive-menu visible
- [ ] No regression on languages, fellows, territories archive menus

🤖 Generated with [Claude Code](https://claude.com/claude-code)