### PR TITLE
Convert linguistic_genealogy to linguistic-genealogy taxonomy

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -497,7 +497,7 @@ parameters:
 
 		-
 			message: "#^Function get_field not found\\.$#"
-			count: 11
+			count: 10
 			path: wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
 
 		-
@@ -777,7 +777,7 @@ parameters:
 
 		-
 			message: "#^Function get_field not found\\.$#"
-			count: 7
+			count: 6
 			path: wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
 
 		-

--- a/tests/unit/GalleryQueryArgsTest.php
+++ b/tests/unit/GalleryQueryArgsTest.php
@@ -120,19 +120,6 @@ class GalleryQueryArgsTest extends TestCase {
 		$this->assertSame( '=', $args['meta_query'][0]['compare'] );
 	}
 
-	public function test_linguistic_genealogy_uses_equals_compare() {
-		$atts = $this->base_atts(
-			array(
-				'meta_key'   => 'linguistic_genealogy',
-				'meta_value' => 'Indo-European',
-			)
-		);
-		$this->mock_wp_parse_args( $atts );
-
-		$result = build_gallery_query_args( $atts );
-		$this->assertSame( '=', $result['meta_query'][0]['compare'] );
-	}
-
 	public function test_generic_meta_key_multiple_values_build_or_meta_query() {
 		$atts = $this->base_atts(
 			array(

--- a/wp-content/plugins/wt-gallery/includes/queries.php
+++ b/wp-content/plugins/wt-gallery/includes/queries.php
@@ -45,7 +45,7 @@ function build_gallery_query_args( $atts = array() ) {
 			$compare_operator = 'LIKE';
 			if ( $atts['meta_key'] === 'fellow_language' ) {
 				$val_array = array_map( fn( $v ) => '"' . intval( $v ) . '"', $val_array );
-			} elseif ( in_array( $atts['meta_key'], array( 'nations_of_origin', 'linguistic_genealogy' ), true ) ) {
+			} elseif ( in_array( $atts['meta_key'], array( 'nations_of_origin' ), true ) ) {
 				$compare_operator = '=';
 			}
 

--- a/wp-content/themes/blankslate-child/acf-json/group_614a2f1facd00.json
+++ b/wp-content/themes/blankslate-child/acf-json/group_614a2f1facd00.json
@@ -157,14 +157,16 @@
             "return_format": "object",
             "field_type": "multi_select",
             "allow_null": 1,
-            "allow_in_bindings": 0
+            "allow_in_bindings": 0,
+            "multiple": 0,
+            "bidirectional_target": []
         },
         {
-            "key": "field_614a2f573b681",
+            "key": "field_6810db1b101e5",
             "label": "Linguistic Genealogy",
-            "name": "linguistic_genealogy",
+            "name": "linguistic_genealogy_taxonomy",
             "aria-label": "",
-            "type": "text",
+            "type": "taxonomy",
             "instructions": "",
             "required": 0,
             "conditional_logic": 0,
@@ -173,12 +175,17 @@
                 "class": "",
                 "id": ""
             },
-            "default_value": "",
-            "maxlength": "",
-            "allow_in_bindings": 1,
-            "placeholder": "",
-            "prepend": "",
-            "append": ""
+            "taxonomy": "linguistic-genealogy",
+            "add_term": 0,
+            "save_terms": 1,
+            "load_terms": 1,
+            "return_format": "object",
+            "field_type": "multi_select",
+            "allow_null": 1,
+            "allow_in_bindings": 0,
+            "bidirectional": 0,
+            "multiple": 0,
+            "bidirectional_target": []
         },
         {
             "key": "field_64d679ec11f17",
@@ -462,6 +469,27 @@
             "bidirectional_target": []
         },
         {
+            "key": "field_614a2f573b681",
+            "label": "Linguistic Genealogy (legacy)",
+            "name": "linguistic_genealogy",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "Legacy field — use Linguistic Genealogy taxonomy above.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "25",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "allow_in_bindings": 1,
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
             "key": "field_614b90d5d2667",
             "label": "Writing Systems (legacy)",
             "name": "writing_systems",
@@ -501,5 +529,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1771700100
+    "modified": 1771716263
 }

--- a/wp-content/themes/blankslate-child/archive-languages.php
+++ b/wp-content/themes/blankslate-child/archive-languages.php
@@ -4,6 +4,7 @@ get_header();
 $territory_slug         = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
 $territory_post         = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
 $genealogy              = isset( $_GET['genealogy'] ) ? sanitize_text_field( wp_unslash( $_GET['genealogy'] ) ) : '';
+$genealogy_term         = $genealogy ? get_term_by( 'slug', $genealogy, 'linguistic-genealogy' ) : null;
 $writing_system         = isset( $_GET['writing_system'] ) ? sanitize_text_field( wp_unslash( $_GET['writing_system'] ) ) : '';
 $writing_system_term    = $writing_system ? get_term_by( 'slug', $writing_system, 'writing-system' ) : null;
 $archive_columns        = 5;
@@ -35,9 +36,9 @@ if ( $territory_post ) {
 		'term'           => '',
 		'link_out'       => '',
 	);
-} elseif ( $genealogy ) {
+} elseif ( $genealogy_term ) {
 	$params = array(
-		'title'          => $genealogy . ' linguistic family',
+		'title'          => $genealogy_term->name . ' linguistic family',
 		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
 		'show_total'     => 'true',
 		'post_type'      => 'languages',
@@ -46,13 +47,13 @@ if ( $territory_post ) {
 		'orderby'        => 'title',
 		'order'          => 'asc',
 		'pagination'     => 'true',
-		'meta_key'       => 'linguistic_genealogy',
-		'meta_value'     => $genealogy,
+		'meta_key'       => '',
+		'meta_value'     => '',
 		'selected_posts' => '',
 		'display_blank'  => 'true',
 		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
+		'taxonomy'       => 'linguistic-genealogy',
+		'term'           => $genealogy_term->slug,
 		'link_out'       => '',
 	);
 } elseif ( $writing_system_term ) {

--- a/wp-content/themes/blankslate-child/includes/custom-post-types/languages.php
+++ b/wp-content/themes/blankslate-child/includes/custom-post-types/languages.php
@@ -40,6 +40,28 @@ function create_post_type_languages() {
 }
 
 // ====================
+// Register Linguistic Genealogy Taxonomy
+// ====================
+add_action( 'init', 'wt_register_linguistic_genealogy_taxonomy' );
+function wt_register_linguistic_genealogy_taxonomy() {
+	register_taxonomy(
+		'linguistic-genealogy',
+		array( 'languages' ),
+		array(
+			'labels'             => array(
+				'name'          => __( 'Linguistic Genealogies' ),
+				'singular_name' => __( 'Linguistic Genealogy' ),
+			),
+			'hierarchical'       => false,
+			'public'             => true,
+			'show_in_rest'       => true,
+			'publicly_queryable' => false,
+			'rewrite'            => false,
+		)
+	);
+}
+
+// ====================
 // Register Writing System Taxonomy
 // ====================
 add_action( 'init', 'wt_register_writing_system_taxonomy' );

--- a/wp-content/themes/blankslate-child/includes/search-filter.php
+++ b/wp-content/themes/blankslate-child/includes/search-filter.php
@@ -65,11 +65,6 @@ function searchfilter( $query ) {
 							'compare' => 'LIKE',
 						),
 						array(
-							'key'     => 'linguistic_genealogy',
-							'value'   => $languages_search,
-							'compare' => '=',
-						),
-						array(
 							'key'     => 'video_title',
 							'value'   => $languages_search,
 							'compare' => 'LIKE',

--- a/wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
+++ b/wp-content/themes/blankslate-child/modules/languages/meta--languages-single.php
@@ -49,13 +49,13 @@ if ( have_rows( 'wikipedia_editions' ) ) {
 		}
 	}
 
-	$alternate_names      = get_field( 'alternate_names' );
-	$iso_code             = get_field( 'iso_code' );
-	$glottocode           = get_field( 'glottocode' );
-	$nations_of_origin    = get_field( 'nations_of_origin' );
-	$writing_system_terms = get_the_terms( get_the_ID(), 'writing-system' );
-	$linguistic_genealogy = get_field( 'linguistic_genealogy' );
-	$egids                = get_field( 'egids_status' );
+	$alternate_names            = get_field( 'alternate_names' );
+	$iso_code                   = get_field( 'iso_code' );
+	$glottocode                 = get_field( 'glottocode' );
+	$nations_of_origin          = get_field( 'nations_of_origin' );
+	$writing_system_terms       = get_the_terms( get_the_ID(), 'writing-system' );
+	$linguistic_genealogy_terms = get_the_terms( get_the_ID(), 'linguistic-genealogy' );
+	$egids                      = get_field( 'egids_status' );
 	?>
 <div class="wt_meta--languages-single">
 	<h1>
@@ -101,7 +101,7 @@ if ( have_rows( 'wikipedia_editions' ) ) {
 
 		</div>
 	<?php endif; ?>
-	<?php if ( $nations_of_origin || ( $writing_system_terms && ! is_wp_error( $writing_system_terms ) ) || $linguistic_genealogy || $egids ) : ?>
+	<?php if ( $nations_of_origin || ( $writing_system_terms && ! is_wp_error( $writing_system_terms ) ) || ( $linguistic_genealogy_terms && ! is_wp_error( $linguistic_genealogy_terms ) ) || $egids ) : ?>
 		<div class="metadata" id="metadata">
 			<strong class="wt_sectionHeader mobile-accordion-header">Metadata</strong>
 			<div class="mobile-accordion-content">
@@ -125,12 +125,16 @@ if ( have_rows( 'wikipedia_editions' ) ) {
 					</p>
 				<?php endif; ?>
 
-				<?php if ( $linguistic_genealogy ) : ?>
+				<?php if ( $linguistic_genealogy_terms && ! is_wp_error( $linguistic_genealogy_terms ) ) : ?>
 					<strong>Linguistic genealogy</strong>
 					<p class="wt_text--label">
-						<a href="<?php echo esc_url( add_query_arg( 'genealogy', rawurlencode( $linguistic_genealogy ), get_post_type_archive_link( 'languages' ) ) ); ?>">
-							<?php echo esc_html( $linguistic_genealogy ); ?>
-						</a>
+						<?php
+						$lg_links = array();
+						foreach ( $linguistic_genealogy_terms as $lg_term ) {
+							$lg_links[] = '<a href="' . esc_url( add_query_arg( 'genealogy', $lg_term->slug, get_post_type_archive_link( 'languages' ) ) ) . '">' . esc_html( $lg_term->name ) . '</a>';
+						}
+						echo implode( ', ', $lg_links );
+						?>
 					</p>
 				<?php endif; ?>
 

--- a/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+++ b/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
@@ -92,12 +92,12 @@
 			?>
 			<li>
 				<?php
-				$language_url         = get_the_permalink();
-				$standard_name        = get_field( 'standard_name' );
-				$alternate_names      = get_field( 'alternate_names' );
-				$nations_of_origin    = get_field( 'nations_of_origin' );
-				$writing_system_terms = get_the_terms( get_the_ID(), 'writing-system' );
-				$linguistic_genealogy = get_field( 'linguistic_genealogy' );
+				$language_url               = get_the_permalink();
+				$standard_name              = get_field( 'standard_name' );
+				$alternate_names            = get_field( 'alternate_names' );
+				$nations_of_origin          = get_field( 'nations_of_origin' );
+				$writing_system_terms       = get_the_terms( get_the_ID(), 'writing-system' );
+				$linguistic_genealogy_terms = get_the_terms( get_the_ID(), 'linguistic-genealogy' );
 				?>
 				<strong class="wt_sectionHeader"><a href="<?php echo $language_url; ?>"><?php echo $standard_name; ?></a></strong>
 				<ul>
@@ -125,13 +125,17 @@
 					</li>
 				<?php endif; ?>
 
-				<?php if ( $linguistic_genealogy ) : ?>
+				<?php if ( $linguistic_genealogy_terms && ! is_wp_error( $linguistic_genealogy_terms ) ) : ?>
 					<li>
 						<p>Linguistic genealogy</p>
 						<p class="wt_text--label">
-							<a href="<?php echo esc_url( add_query_arg( 'genealogy', rawurlencode( $linguistic_genealogy ), get_post_type_archive_link( 'languages' ) ) ); ?>">
-								<?php echo esc_html( $linguistic_genealogy ); ?>
-							</a>
+							<?php
+							$lg_links = array();
+							foreach ( $linguistic_genealogy_terms as $lg_term ) {
+								$lg_links[] = '<a href="' . esc_url( add_query_arg( 'genealogy', $lg_term->slug, get_post_type_archive_link( 'languages' ) ) ) . '">' . esc_html( $lg_term->name ) . '</a>';
+							}
+							echo implode( ', ', $lg_links );
+							?>
 						</p>
 					</li>
 				<?php endif; ?>


### PR DESCRIPTION
## Summary
- Registers `linguistic-genealogy` as a proper WP taxonomy (mirrors the `writing-system` taxonomy added in PR #467)
- Migrates display/filtering logic from ACF meta field to `get_the_terms()` + `tax_query`
- Removes `linguistic_genealogy` from gallery meta exact-match list and search filter meta clause
- Adds ACF taxonomy selector in admin (legacy text field retained at bottom as migration source)
- Handles multi-value genealogy entries correctly (e.g. "Indo-European, Slavic" → two separate terms)

## Files changed
| File | Change |
|------|--------|
| `languages.php` | Register `linguistic-genealogy` taxonomy |
| `acf-json/group_614a2f1facd00.json` | Add taxonomy selector field; rename legacy field |
| `archive-languages.php` | `?genealogy=` now resolved via `get_term_by()` + `tax_query` |
| `meta--languages-single.php` | Use `get_the_terms()` for both taxonomies; render as linked terms |
| `meta--videos-single.php` | Same lookup inside featured_languages loop |
| `queries.php` | Remove `linguistic_genealogy` from exact-match list |
| `search-filter.php` | Remove `linguistic_genealogy` meta clause |
| `GalleryQueryArgsTest.php` | Remove obsolete `test_linguistic_genealogy_uses_equals_compare` |
| `phpstan-baseline.neon` | Adjust counts after removing `get_field()` calls |

## Migration (run on each environment after deploy)
The migration script lives at `./temp/migrate-linguistic-genealogy.php` (gitignored — copy manually to server):
```bash
wp eval-file ./temp/migrate-linguistic-genealogy.php --allow-root
```
The script:
1. Clears all existing `linguistic-genealogy` terms (removes any previously merged values)
2. Re-reads the legacy `linguistic_genealogy` ACF text field for each published language post
3. Splits on commas so "Indo-European, Slavic" becomes two discrete terms
4. Processes in batches of 50 to avoid OOM on staging

## Test plan
- [ ] Deploy code + run migration on staging
- [ ] Spot-check a few language posts in WP admin — "Linguistic Genealogy" taxonomy box shows individual terms (not comma-merged)
- [ ] Language single page: genealogy values render as comma-separated clickable links (e.g. "Indo-European, Slavic" → two links each pointing to `?genealogy=<slug>`)
- [ ] `/languages/?genealogy=indo-european` → gallery titled "Indo-European linguistic family"
- [ ] `/languages/?writing_system=latin` still works (no regression)
- [ ] `/languages/?territory=<slug>` still works (no regression)
- [ ] Video single page: featured language genealogy terms render as archive links
- [ ] `composer lint` → 0 errors
- [ ] `composer test` → 56 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)