### PR TITLE
Add wt-airtable-sync Phase 0 scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ wp-config.php
 !/wp-content/plugins/typeahead/
 !/wp-content/plugins/typeahead/build
 !/wp-content/plugins/wt-gallery/
+!/wp-content/plugins/wt-airtable-sync/
 
 # Uploads
 /wp-content/uploads/
@@ -59,6 +60,7 @@ ggstemp.html
 readme_backup.md
 temp/
 temp-captions/
+docs/
 transmit_sync_offset_2135232021
 /wp-content/backups-dup-pro/
 tool-sync-db-from-prod.sh

--- a/wp-content/plugins/wt-airtable-sync/config/field-maps.php
+++ b/wp-content/plugins/wt-airtable-sync/config/field-maps.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Field maps for wt-airtable-sync.
+ *
+ * Maps Airtable field names to WP meta keys for each supported CPT.
+ * Used by Sync_API to validate the post_type route parameter, and by
+ * the upsert handler (Phase 1+) to drive field writes.
+ *
+ * Structure per field entry:
+ *   'airtable_field' => [
+ *       'meta_key'  => string,   // wp_postmeta key (ACF uses the field name)
+ *       'acf'       => bool,     // true = write via update_field(); false = update_post_meta()
+ *       'acf_type'  => string|null,  // ACF field type; drives resolver selection
+ *       'transform' => string|null,  // named transform: 'resolve_post_ids', 'upload_media', or null
+ *   ]
+ *
+ * Phase 0: empty — all post_type route params are rejected with 400.
+ * Phase 1: 'languages' entry added.
+ * Phase 2: 'videos', 'captions', 'lexicons' entries added.
+ *          'resources' deferred until Airtable/WP count mismatch is resolved.
+ *
+ * Full field map draft: docs/make-audit-findings.md § 9
+ *
+ * @return array<string, array<string, array<string, mixed>>>
+ */
+return array();

--- a/wp-content/plugins/wt-airtable-sync/includes/class-logger.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-logger.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Logger — thin wrapper around error_log with a consistent prefix and level labels.
+ *
+ * Usage:
+ *   Logger::info( 'Sync started for post_type=languages' );
+ *   Logger::error( 'Upsert failed: ' . $e->getMessage() );
+ *
+ * Output lands in the server error log (the same destination as native WP errors).
+ * Phase 1+ may extend this to write to a dedicated log file or WP admin panel.
+ *
+ * @package WT\AirtableSync
+ */
+
+namespace WT\AirtableSync;
+
+class Logger {
+
+	private const PREFIX = '[wt-airtable-sync]';
+
+	public static function info( string $message ): void {
+		self::write( 'INFO', $message );
+	}
+
+	public static function error( string $message ): void {
+		self::write( 'ERROR', $message );
+	}
+
+	private static function write( string $level, string $message ): void {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+		error_log( sprintf( '%s [%s] %s', self::PREFIX, $level, $message ) );
+	}
+}

--- a/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Sync_API — REST route registration and request handling.
+ *
+ * Registers: POST /wp-json/wikitongues/v1/sync/{post_type}
+ *
+ * Authentication: X-WT-Sync-Key header, compared in constant time against
+ * the WT_SYNC_API_KEY constant defined in wp-config.php.
+ *
+ * Phase 0: endpoint authenticates and validates the post_type parameter, then
+ * returns a 200 stub response. Upsert logic is implemented in Phase 1.
+ *
+ * @package WT\AirtableSync
+ */
+
+namespace WT\AirtableSync;
+
+class Sync_API {
+
+	private const REST_NAMESPACE = 'wikitongues/v1';
+	private const REST_ROUTE     = '/sync/(?P<post_type>[a-z_-]+)';
+
+	public function register_routes(): void {
+		register_rest_route(
+			self::REST_NAMESPACE,
+			self::REST_ROUTE,
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_sync' ),
+				'permission_callback' => array( $this, 'check_auth' ),
+				'args'                => array(
+					'post_type' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+						'validate_callback' => array( $this, 'validate_post_type' ),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Authenticate the request via the X-WT-Sync-Key header.
+	 *
+	 * Returns WP_Error (503) if the server constant is absent — this signals a
+	 * misconfiguration rather than a bad client request.
+	 * Returns WP_Error (401) if the key is wrong or missing.
+	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return true|\WP_Error
+	 */
+	public function check_auth( \WP_REST_Request $request ): true|\WP_Error {
+		if ( ! defined( 'WT_SYNC_API_KEY' ) || '' === WT_SYNC_API_KEY ) {
+			return new \WP_Error(
+				'wt_sync_not_configured',
+				'WT_SYNC_API_KEY is not defined on this server.',
+				array( 'status' => 503 )
+			);
+		}
+
+		$provided = (string) $request->get_header( 'X-WT-Sync-Key' );
+
+		if ( ! hash_equals( WT_SYNC_API_KEY, $provided ) ) {
+			Logger::error( 'Rejected request: invalid X-WT-Sync-Key.' );
+
+			return new \WP_Error(
+				'wt_sync_unauthorized',
+				'Invalid or missing X-WT-Sync-Key header.',
+				array( 'status' => 401 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate that the post_type path segment has a field map defined.
+	 *
+	 * Phase 0: field-maps.php returns an empty array, so all post types are
+	 * rejected with 400. This is intentional — Phase 1 populates the map.
+	 *
+	 * @param string $post_type Value from the URL path.
+	 * @return bool
+	 */
+	public function validate_post_type( string $post_type ): bool {
+		$maps      = require WT_AIRTABLE_SYNC_DIR . 'config/field-maps.php';
+		$supported = array_keys( $maps );
+
+		return in_array( $post_type, $supported, true );
+	}
+
+	/**
+	 * Handle a validated, authenticated sync request.
+	 *
+	 * Phase 1 will implement the full upsert pipeline here.
+	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle_sync( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		$post_type = $request->get_param( 'post_type' );
+
+		Logger::info( "Sync request received for post_type={$post_type}." );
+
+		// Phase 1 will replace this stub with upsert logic.
+		return new \WP_REST_Response(
+			array(
+				'status'    => 'ok',
+				'post_type' => $post_type,
+				'message'   => 'Phase 0 scaffold. Sync logic not yet implemented.',
+			),
+			200
+		);
+	}
+}

--- a/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
@@ -33,7 +33,6 @@ class Sync_API {
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_key',
-						'validate_callback' => array( $this, 'validate_post_type' ),
 					),
 				),
 			)
@@ -75,31 +74,29 @@ class Sync_API {
 	}
 
 	/**
-	 * Validate that the post_type path segment has a field map defined.
+	 * Handle an authenticated sync request.
 	 *
-	 * Phase 0: field-maps.php returns an empty array, so all post types are
-	 * rejected with 400. This is intentional — Phase 1 populates the map.
+	 * Validates post_type here (after auth) so permission_callback always
+	 * runs first — a bad key gets 401 before any business logic is checked.
 	 *
-	 * @param string $post_type Value from the URL path.
-	 * @return bool
-	 */
-	public function validate_post_type( string $post_type ): bool {
-		$maps      = require WT_AIRTABLE_SYNC_DIR . 'config/field-maps.php';
-		$supported = array_keys( $maps );
-
-		return in_array( $post_type, $supported, true );
-	}
-
-	/**
-	 * Handle a validated, authenticated sync request.
-	 *
-	 * Phase 1 will implement the full upsert pipeline here.
+	 * Phase 1 will replace the stub response with upsert logic.
 	 *
 	 * @param \WP_REST_Request $request Incoming REST request.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function handle_sync( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$post_type = $request->get_param( 'post_type' );
+
+		$maps      = require WT_AIRTABLE_SYNC_DIR . 'config/field-maps.php';
+		$supported = array_keys( $maps );
+
+		if ( ! in_array( $post_type, $supported, true ) ) {
+			return new \WP_Error(
+				'wt_sync_unsupported_post_type',
+				sprintf( 'No field map defined for post_type "%s".', $post_type ),
+				array( 'status' => 400 )
+			);
+		}
 
 		Logger::info( "Sync request received for post_type={$post_type}." );
 

--- a/wp-content/plugins/wt-airtable-sync/uninstall.php
+++ b/wp-content/plugins/wt-airtable-sync/uninstall.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Runs when the plugin is deleted via the WP admin.
+ * Removes any options written by this plugin.
+ * Does NOT delete synced post content — that data belongs to the site.
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+delete_option( 'wt_sync_key_missing' );

--- a/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
+++ b/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Plugin Name:       WT Airtable Sync
+ * Plugin URI:        https://github.com/wikitongues/wikitongues.org
+ * Description:       HTTP transport layer for Airtable → WordPress content sync. Make.com POSTs raw Airtable payloads; this plugin owns all field mapping, relationship resolution, and ACF writes in code.
+ * Version:           0.1.0
+ * Requires at least: 6.0
+ * Requires PHP:      8.2
+ * Author:            Wikitongues
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+namespace WT\AirtableSync;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'WT_AIRTABLE_SYNC_VERSION', '0.1.0' );
+define( 'WT_AIRTABLE_SYNC_FILE', __FILE__ );
+define( 'WT_AIRTABLE_SYNC_DIR', plugin_dir_path( __FILE__ ) );
+
+require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-logger.php';
+require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-sync-api.php';
+
+register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
+register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
+
+/**
+ * Activation: warn if WT_SYNC_API_KEY is not yet defined in wp-config.php.
+ */
+function activate(): void {
+	if ( ! defined( 'WT_SYNC_API_KEY' ) || '' === WT_SYNC_API_KEY ) {
+		update_option( 'wt_sync_key_missing', true );
+	} else {
+		delete_option( 'wt_sync_key_missing' );
+	}
+}
+
+/**
+ * Deactivation: clean up transient flags.
+ */
+function deactivate(): void {
+	delete_option( 'wt_sync_key_missing' );
+}
+
+/**
+ * Show an admin notice when WT_SYNC_API_KEY is absent.
+ * The endpoint returns 503 in this state, so the notice is actionable.
+ */
+add_action(
+	'admin_notices',
+	function (): void {
+		if ( ! defined( 'WT_SYNC_API_KEY' ) || '' === WT_SYNC_API_KEY ) {
+			echo '<div class="notice notice-error"><p>';
+			echo '<strong>WT Airtable Sync:</strong> ';
+			echo '<code>WT_SYNC_API_KEY</code> is not defined in <code>wp-config.php</code>. ';
+			echo 'The sync endpoint will reject all requests until this constant is set.';
+			echo '</p></div>';
+		}
+	}
+);
+
+/**
+ * Register the sync REST route once the REST API is initialised.
+ */
+add_action(
+	'rest_api_init',
+	function (): void {
+		( new Sync_API() )->register_routes();
+	}
+);


### PR DESCRIPTION
## Summary

- New plugin `wt-airtable-sync` scaffolded at `wp-content/plugins/wt-airtable-sync/`
- Registers `POST /wp-json/wikitongues/v1/sync/{post_type}` — authenticated via `X-WT-Sync-Key` header checked against `WT_SYNC_API_KEY` constant in `wp-config.php`
- Phase 0 stub: endpoint authenticates, validates `post_type` against `config/field-maps.php`, logs the request, returns 200. All `post_type` values rejected with 400 until Phase 1 populates the field map.
- Admin notice shown when `WT_SYNC_API_KEY` is not defined
- `docs/` added to `.gitignore` (contains audit findings with internal operational details)
- `plan.md` / `plan-archive.md` updated with completed Make.com audit and plugin build sequence

## Plugin structure

```
wp-content/plugins/wt-airtable-sync/
├── wt-airtable-sync.php          # Plugin header, bootstrap, hooks
├── config/
│   └── field-maps.php            # Empty stub — populated Phase 1+
├── includes/
│   ├── class-sync-api.php        # REST route + auth + stub handler
│   └── class-logger.php          # error_log wrapper
└── uninstall.php
```

## To activate

Add to `wp-config.php`:
```php
define( 'WT_SYNC_API_KEY', 'your-secret-key-here' );
```
Then activate the plugin in WP Admin → Plugins. An admin notice will appear if the constant is absent.

## Test plan

- [x] Activate plugin — no PHP errors, no fatal
- [x] Omit `WT_SYNC_API_KEY` from wp-config — admin notice appears
- [x] `POST /wp-json/wikitongues/v1/sync/languages` with wrong key → 401
- [x] `POST /wp-json/wikitongues/v1/sync/languages` with correct key → 400 (post_type not yet in field map)
- [x] `POST /wp-json/wikitongues/v1/sync/languages` with no key defined on server → 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)