### PR TITLE
Add wt-airtable-sync Phase 1: languages sync endpoint

### DIFF
--- a/wp-content/plugins/wt-airtable-sync/config/field-maps.php
+++ b/wp-content/plugins/wt-airtable-sync/config/field-maps.php
@@ -2,25 +2,123 @@
 /**
  * Field maps for wt-airtable-sync.
  *
- * Maps Airtable field names to WP meta keys for each supported CPT.
- * Used by Sync_API to validate the post_type route parameter, and by
- * the upsert handler (Phase 1+) to drive field writes.
+ * Each top-level key is a WP CPT slug. The controller reads this file to:
+ *   1. Validate that an incoming post_type has a map defined.
+ *   2. Know which payload keys to write, how to write them, and whether
+ *      to resolve Airtable titles to WP post IDs first.
  *
- * Structure per field entry:
- *   'airtable_field' => [
- *       'meta_key'  => string,   // wp_postmeta key (ACF uses the field name)
- *       'acf'       => bool,     // true = write via update_field(); false = update_post_meta()
- *       'acf_type'  => string|null,  // ACF field type; drives resolver selection
- *       'transform' => string|null,  // named transform: 'resolve_post_ids', 'upload_media', or null
+ * Payload shape expected from Make.com for each CPT:
+ *   - 'airtable_id'  (string)  Airtable record ID (recXXXXX) — used for upsert
+ *   - 'post_title'   (string)  WP post title
+ *   - 'post_status'  (string)  WP post status (publish / draft / etc.)
+ *   - All field keys listed in the 'meta' sub-array below
+ *
+ * Field entry shape:
+ *   'payload_key' => [
+ *       'meta_key'  => string,       WP postmeta key (ACF uses the field name as key)
+ *       'acf'       => bool,         true  → update_field(); false → update_post_meta()
+ *       'acf_type'  => string|null,  ACF field type — drives resolver selection
+ *       'post_type' => string|null,  Target CPT for post_object resolution; null otherwise
  *   ]
  *
- * Phase 0: empty — all post_type route params are rejected with 400.
- * Phase 1: 'languages' entry added.
- * Phase 2: 'videos', 'captions', 'lexicons' entries added.
- *          'resources' deferred until Airtable/WP count mismatch is resolved.
+ * post_object fields receive comma-separated titles (or an array) from the
+ * payload; Field_Resolver::resolve() converts them to WP post IDs before writing.
  *
- * Full field map draft: docs/make-audit-findings.md § 9
+ * Phase 1: languages only.
+ * Phase 2: videos, captions, lexicons.
+ * Deferred: resources (Airtable/WP count mismatch — see docs/make-audit-findings.md F3).
  *
  * @return array<string, array<string, array<string, mixed>>>
  */
-return array();
+return array(
+
+	'languages' => array(
+
+		// --- Scalar fields (written directly) ---
+
+		'standard_name'        => array(
+			'meta_key'  => 'standard_name',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'alternate_names'      => array(
+			'meta_key'  => 'alternate_names',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'nations_of_origin'    => array(
+			'meta_key'  => 'nations_of_origin',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'writing_systems'      => array(
+			'meta_key'  => 'writing_systems',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'linguistic_genealogy' => array(
+			'meta_key'  => 'linguistic_genealogy',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'iso_code'             => array(
+			'meta_key'  => 'iso_code',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'glottocode'           => array(
+			'meta_key'  => 'glottocode',
+			'acf'       => true,
+			'acf_type'  => 'text',
+			'post_type' => null,
+		),
+		'olac_url'             => array(
+			'meta_key'  => 'olac_url',
+			'acf'       => true,
+			'acf_type'  => 'url',
+			'post_type' => null,
+		),
+		'wikipedia_url'        => array(
+			'meta_key'  => 'wikipedia_url',
+			'acf'       => true,
+			'acf_type'  => 'url',
+			'post_type' => null,
+		),
+
+		// --- post_object fields (titles resolved to WP post IDs before writing) ---
+		// post_type is the WP CPT searched for each title value.
+		// Confirmed from ACF field group group_614a2f1facd00.json.
+
+		'speakers_recorded'    => array(
+			'meta_key'  => 'speakers_recorded',
+			'acf'       => true,
+			'acf_type'  => 'post_object',
+			'post_type' => 'videos',
+		),
+		'lexicon_source'       => array(
+			'meta_key'  => 'lexicon_source',
+			'acf'       => true,
+			'acf_type'  => 'post_object',
+			'post_type' => 'lexicons',
+		),
+		'lexicon_target'       => array(
+			'meta_key'  => 'lexicon_target',
+			'acf'       => true,
+			'acf_type'  => 'post_object',
+			'post_type' => 'lexicons',
+		),
+		'external_resources'   => array(
+			'meta_key'  => 'external_resources',
+			'acf'       => true,
+			'acf_type'  => 'post_object',
+			'post_type' => 'resources',
+		),
+	),
+
+);

--- a/wp-content/plugins/wt-airtable-sync/includes/class-field-resolver.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-field-resolver.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Field_Resolver — converts Airtable title strings to WP post IDs.
+ *
+ * Used for ACF post_object fields where the payload contains the post title
+ * (or a comma-separated list of titles) rather than a WP post ID.
+ *
+ * Replaces the deprecated get_page_by_title() used by the old
+ * post-object-helpers.php integration. Uses WP_Query instead.
+ *
+ * @package WT\AirtableSync
+ */
+
+namespace WT\AirtableSync;
+
+class Field_Resolver {
+
+	/**
+	 * Resolve one or more post titles to an array of WP post IDs.
+	 *
+	 * @param string|string[] $value     Single title, comma-separated titles, or array of titles.
+	 * @param string          $post_type The CPT to search within.
+	 * @return int[]                     Array of matched WP post IDs. Unmatched titles are skipped.
+	 */
+	public static function resolve( string|array $value, string $post_type ): array {
+		$titles = self::normalise_titles( $value );
+
+		if ( empty( $titles ) ) {
+			return array();
+		}
+
+		$ids = array();
+
+		foreach ( $titles as $title ) {
+			$id = self::find_post_by_title( $title, $post_type );
+
+			if ( $id ) {
+				$ids[] = $id;
+			} else {
+				Logger::error(
+					sprintf(
+						'Field_Resolver: no %s post found for title "%s".',
+						$post_type,
+						$title
+					)
+				);
+			}
+		}
+
+		return $ids;
+	}
+
+	/**
+	 * Find a single post ID by exact title within a given CPT.
+	 *
+	 * Returns 0 if no match is found.
+	 *
+	 * @param string $title     Post title to search for.
+	 * @param string $post_type CPT slug to search within.
+	 * @return int
+	 */
+	private static function find_post_by_title( string $title, string $post_type ): int {
+		$query = new \WP_Query(
+			array(
+				'post_type'              => $post_type,
+				'title'                  => $title,
+				'post_status'            => 'any',
+				'posts_per_page'         => 1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		if ( $query->have_posts() ) {
+			return (int) $query->posts[0]->ID;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Normalise the incoming value to a flat array of trimmed, non-empty title strings.
+	 *
+	 * Handles:
+	 *   - Array of strings
+	 *   - Comma-separated string  (e.g. "Chichewa, Tonga")
+	 *   - Non-breaking spaces (chr 194 + chr 160) from Airtable copy-paste
+	 *
+	 * @param string|string[] $value Raw value from the payload.
+	 * @return string[]
+	 */
+	private static function normalise_titles( string|array $value ): array {
+		$raw = is_array( $value ) ? $value : explode( ',', $value );
+
+		return array_values(
+			array_filter(
+				array_map(
+					static function ( string $title ): string {
+						// Strip Airtable non-breaking spaces before trimming.
+						$title = str_replace( "\xc2\xa0", ' ', $title );
+						return trim( $title );
+					},
+					$raw
+				)
+			)
+		);
+	}
+}

--- a/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-sync-api.php
@@ -7,9 +7,6 @@
  * Authentication: X-WT-Sync-Key header, compared in constant time against
  * the WT_SYNC_API_KEY constant defined in wp-config.php.
  *
- * Phase 0: endpoint authenticates and validates the post_type parameter, then
- * returns a 200 stub response. Upsert logic is implemented in Phase 1.
- *
  * @package WT\AirtableSync
  */
 
@@ -76,21 +73,17 @@ class Sync_API {
 	/**
 	 * Handle an authenticated sync request.
 	 *
-	 * Validates post_type here (after auth) so permission_callback always
+	 * post_type is validated here (after auth) so permission_callback always
 	 * runs first — a bad key gets 401 before any business logic is checked.
-	 *
-	 * Phase 1 will replace the stub response with upsert logic.
 	 *
 	 * @param \WP_REST_Request $request Incoming REST request.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function handle_sync( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$post_type = $request->get_param( 'post_type' );
-
 		$maps      = require WT_AIRTABLE_SYNC_DIR . 'config/field-maps.php';
-		$supported = array_keys( $maps );
 
-		if ( ! in_array( $post_type, $supported, true ) ) {
+		if ( ! isset( $maps[ $post_type ] ) ) {
 			return new \WP_Error(
 				'wt_sync_unsupported_post_type',
 				sprintf( 'No field map defined for post_type "%s".', $post_type ),
@@ -98,16 +91,22 @@ class Sync_API {
 			);
 		}
 
-		Logger::info( "Sync request received for post_type={$post_type}." );
+		$payload = $request->get_json_params();
 
-		// Phase 1 will replace this stub with upsert logic.
-		return new \WP_REST_Response(
-			array(
-				'status'    => 'ok',
-				'post_type' => $post_type,
-				'message'   => 'Phase 0 scaffold. Sync logic not yet implemented.',
-			),
-			200
-		);
+		if ( empty( $payload ) ) {
+			return new \WP_Error(
+				'wt_sync_empty_payload',
+				'Request body is empty or not valid JSON.',
+				array( 'status' => 400 )
+			);
+		}
+
+		$result = ( new Sync_Controller() )->sync( $post_type, $payload, $maps[ $post_type ] );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new \WP_REST_Response( $result, 200 );
 	}
 }

--- a/wp-content/plugins/wt-airtable-sync/includes/class-sync-controller.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-sync-controller.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Sync_Controller — upsert pipeline for a single Airtable record.
+ *
+ * Responsibilities:
+ *   1. Locate the existing WP post (by _airtable_record_id → iso_code → post_title).
+ *   2. Create or update the post.
+ *   3. Write all meta fields defined in the CPT's field map.
+ *   4. Stamp _airtable_record_id on every write so future syncs use the stable ID.
+ *
+ * Expected payload keys (all optional except airtable_id):
+ *   - airtable_id  (string)  Airtable record ID, e.g. "recXXXXXXXX"
+ *   - post_title   (string)  WP post title
+ *   - post_status  (string)  publish / draft / etc. Defaults to 'publish'.
+ *   - <field_key>  (mixed)   Any key present in the CPT's field map entry.
+ *
+ * @package WT\AirtableSync
+ */
+
+namespace WT\AirtableSync;
+
+class Sync_Controller {
+
+	private const AIRTABLE_ID_KEY = '_airtable_record_id';
+
+	/**
+	 * Process a sync payload for a given post type.
+	 *
+	 * @param string               $post_type WP CPT slug.
+	 * @param array<string, mixed> $payload   Decoded JSON body from the request.
+	 * @param array<string, mixed> $field_map CPT entry from config/field-maps.php.
+	 * @return array{status: string, action: string, post_id: int}|\WP_Error
+	 */
+	public function sync(
+		string $post_type,
+		array $payload,
+		array $field_map
+	): array|\WP_Error {
+		$airtable_id = isset( $payload['airtable_id'] ) ? sanitize_text_field( (string) $payload['airtable_id'] ) : '';
+		$post_title  = isset( $payload['post_title'] ) ? sanitize_text_field( (string) $payload['post_title'] ) : '';
+		$post_status = isset( $payload['post_status'] ) ? sanitize_text_field( (string) $payload['post_status'] ) : 'publish';
+
+		// 1. Locate existing post.
+		$post_id = $this->find_post( $post_type, $airtable_id, $post_title, $payload );
+		$action  = $post_id ? 'updated' : 'created';
+
+		// 2. Create or update the core WP post.
+		$post_id = $this->upsert_post( $post_id, $post_type, $post_title, $post_status );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		// 3. Stamp the stable Airtable record ID.
+		if ( $airtable_id ) {
+			update_post_meta( $post_id, self::AIRTABLE_ID_KEY, $airtable_id );
+		}
+
+		// 4. Write meta fields.
+		$this->write_meta( $post_id, $payload, $field_map );
+
+		Logger::info(
+			sprintf( '%s post_type=%s post_id=%d airtable_id=%s', $action, $post_type, $post_id, $airtable_id )
+		);
+
+		return array(
+			'status'  => 'ok',
+			'action'  => $action,
+			'post_id' => $post_id,
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Lookup
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Find an existing post using a three-step priority lookup:
+	 *   1. _airtable_record_id (stable, preferred)
+	 *   2. iso_code meta key   (languages-specific fallback)
+	 *   3. post_title          (last resort)
+	 *
+	 * Returns 0 if no match is found.
+	 *
+	 * @param string               $post_type   WP CPT slug.
+	 * @param string               $airtable_id Airtable record ID.
+	 * @param string               $post_title  Post title from payload.
+	 * @param array<string, mixed> $payload     Full payload (used for iso_code fallback).
+	 * @return int WP post ID, or 0.
+	 */
+	private function find_post(
+		string $post_type,
+		string $airtable_id,
+		string $post_title,
+		array $payload
+	): int {
+		// 1. Stable Airtable record ID.
+		if ( $airtable_id ) {
+			$id = $this->find_by_meta( $post_type, self::AIRTABLE_ID_KEY, $airtable_id );
+			if ( $id ) {
+				return $id;
+			}
+		}
+
+		// 2. iso_code fallback (languages CPT only).
+		$iso_code = isset( $payload['iso_code'] ) ? sanitize_text_field( (string) $payload['iso_code'] ) : '';
+		if ( $iso_code ) {
+			$id = $this->find_by_meta( $post_type, 'iso_code', $iso_code );
+			if ( $id ) {
+				return $id;
+			}
+		}
+
+		// 3. Post title fallback.
+		if ( $post_title ) {
+			$id = $this->find_by_title( $post_type, $post_title );
+			if ( $id ) {
+				return $id;
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Find a post by a meta key/value pair.
+	 *
+	 * @param string $post_type WP CPT slug.
+	 * @param string $meta_key  Meta key to match.
+	 * @param string $meta_value Meta value to match.
+	 * @return int Post ID, or 0.
+	 */
+	private function find_by_meta( string $post_type, string $meta_key, string $meta_value ): int {
+		$query = new \WP_Query(
+			array(
+				'post_type'              => $post_type,
+				'post_status'            => 'any',
+				'posts_per_page'         => 1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'meta_query'             => array(
+					array(
+						'key'   => $meta_key,
+						'value' => $meta_value,
+					),
+				),
+			)
+		);
+
+		if ( $query->have_posts() ) {
+			return (int) $query->posts[0]->ID;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Find a post by exact post_title match.
+	 *
+	 * @param string $post_type  WP CPT slug.
+	 * @param string $post_title Exact title to match.
+	 * @return int Post ID, or 0.
+	 */
+	private function find_by_title( string $post_type, string $post_title ): int {
+		$query = new \WP_Query(
+			array(
+				'post_type'              => $post_type,
+				'title'                  => $post_title,
+				'post_status'            => 'any',
+				'posts_per_page'         => 1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		if ( $query->have_posts() ) {
+			return (int) $query->posts[0]->ID;
+		}
+
+		return 0;
+	}
+
+	// -------------------------------------------------------------------------
+	// Create / Update
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Insert a new post or update an existing one.
+	 *
+	 * @param int    $post_id     0 to create; existing ID to update.
+	 * @param string $post_type   WP CPT slug.
+	 * @param string $post_title  Post title.
+	 * @param string $post_status Post status.
+	 * @return int|\WP_Error New or existing post ID on success; WP_Error on failure.
+	 */
+	private function upsert_post(
+		int $post_id,
+		string $post_type,
+		string $post_title,
+		string $post_status
+	): int|\WP_Error {
+		$args = array(
+			'post_type'   => $post_type,
+			'post_status' => $post_status,
+		);
+
+		if ( $post_title ) {
+			$args['post_title'] = $post_title;
+			$args['post_name']  = sanitize_title( $post_title );
+		}
+
+		if ( $post_id ) {
+			$args['ID'] = $post_id;
+			$result     = wp_update_post( $args, true );
+		} else {
+			$result = wp_insert_post( $args, true );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			Logger::error( 'upsert_post failed: ' . $result->get_error_message() );
+		}
+
+		return $result;
+	}
+
+	// -------------------------------------------------------------------------
+	// Meta writes
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Write all mapped meta fields from the payload to the post.
+	 *
+	 * post_object fields are resolved to WP post IDs before writing.
+	 * Fields absent from the payload are skipped (no clearing of existing values).
+	 *
+	 * @param int                  $post_id   WP post ID.
+	 * @param array<string, mixed> $payload   Full request payload.
+	 * @param array<string, mixed> $field_map CPT field map from config/field-maps.php.
+	 */
+	private function write_meta( int $post_id, array $payload, array $field_map ): void {
+		foreach ( $field_map as $payload_key => $field ) {
+			if ( ! isset( $payload[ $payload_key ] ) ) {
+				continue;
+			}
+
+			$raw_value = $payload[ $payload_key ];
+			$meta_key  = $field['meta_key'];
+			$is_acf    = (bool) $field['acf'];
+			$acf_type  = $field['acf_type'] ?? null;
+			$cpt       = $field['post_type'] ?? null;
+
+			if ( 'post_object' === $acf_type && $cpt ) {
+				$value = Field_Resolver::resolve( $raw_value, $cpt );
+			} else {
+				$value = $raw_value;
+			}
+
+			if ( $is_acf && function_exists( 'update_field' ) ) {
+				update_field( $meta_key, $value, $post_id );
+			} else {
+				update_post_meta( $post_id, $meta_key, $value );
+			}
+		}
+	}
+}

--- a/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
+++ b/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
@@ -22,6 +22,8 @@ define( 'WT_AIRTABLE_SYNC_FILE', __FILE__ );
 define( 'WT_AIRTABLE_SYNC_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-logger.php';
+require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-field-resolver.php';
+require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-sync-controller.php';
 require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-sync-api.php';
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );


### PR DESCRIPTION
## Summary

- `config/field-maps.php` populated with the `languages` entry (9 scalar fields + 4 post_object relationships)
- `class-field-resolver.php` — resolves Airtable titles to WP post IDs via `WP_Query` (replaces deprecated `get_page_by_title()`)
- `class-sync-controller.php` — full upsert pipeline with three-step lookup
- `class-sync-api.php` — handler wired to controller

## How it works

Make.com POSTs a JSON body to `POST /wp-json/wikitongues/v1/sync/languages`:

```json
{
  "airtable_id": "recXXXXXXXX",
  "post_title":  "lou",
  "post_status": "publish",
  "iso_code":    "lou",
  "standard_name": "Louisiana Creole",
  "alternate_names": "Kouri-Vini",
  "speakers_recorded": "VideoTitle1, VideoTitle2"
}
```

**Upsert lookup order:**
1. `_airtable_record_id` meta (stable — used on all subsequent syncs after first run)
2. `iso_code` meta fallback (languages-specific)
3. `post_title` fallback (last resort)

**On every write:** `_airtable_record_id` is stamped with the Airtable record ID. This self-backfills the stable key on first sync run across all 8,085 existing language posts.

**post_object fields** (`speakers_recorded`, `lexicon_source`, `lexicon_target`, `external_resources`): payload contains titles; `Field_Resolver` converts to WP post IDs via `WP_Query` before `update_field()` is called. Unmatched titles are logged and skipped.

## Test plan

```bash
# 400 — correct key, unsupported post_type
curl -s -w "\n--- HTTP %{http_code} ---\n" -X POST http://localhost:8888/wikitongues/wp-json/wikitongues/v1/sync/videos \
  -H "X-WT-Sync-Key: your-key" -H "Content-Type: application/json"

# 400 — correct key, empty body
curl -s -w "\n--- HTTP %{http_code} ---\n" -X POST http://localhost:8888/wikitongues/wp-json/wikitongues/v1/sync/languages \
  -H "X-WT-Sync-Key: your-key" -H "Content-Type: application/json"

# 200 — create new language post
curl -s -w "\n--- HTTP %{http_code} ---\n" -X POST http://localhost:8888/wikitongues/wp-json/wikitongues/v1/sync/languages \
  -H "X-WT-Sync-Key: your-key" -H "Content-Type: application/json" \
  -d '{"airtable_id":"recTEST001","post_title":"tst","post_status":"draft","iso_code":"tst","standard_name":"Test Language"}'

# 200 — update same post (verify action=updated, same post_id)
curl -s -w "\n--- HTTP %{http_code} ---\n" -X POST http://localhost:8888/wikitongues/wp-json/wikitongues/v1/sync/languages \
  -H "X-WT-Sync-Key: your-key" -H "Content-Type: application/json" \
  -d '{"airtable_id":"recTEST001","post_title":"tst","post_status":"draft","iso_code":"tst","standard_name":"Test Language Updated"}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)