### PR TITLE
Add read-only ACF sidebar field for _airtable_record_id

### DIFF
--- a/wp-content/plugins/wt-airtable-sync/includes/class-acf-fields.php
+++ b/wp-content/plugins/wt-airtable-sync/includes/class-acf-fields.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * ACF_Fields — programmatic field group registration for wt-airtable-sync.
+ *
+ * Registers a read-only "_airtable_record_id" field on every synced CPT so
+ * the Airtable record ID is visible in the post edit screen without DB access.
+ *
+ * The field is read-only via the 'readonly' wrapper attribute; it is never
+ * written by this group — the Sync_Controller stamps the value directly via
+ * update_post_meta() using the AIRTABLE_ID_KEY constant.
+ *
+ * @package WT\AirtableSync
+ */
+
+namespace WT\AirtableSync;
+
+class ACF_Fields {
+
+	/**
+	 * Register local field groups with ACF.
+	 *
+	 * Called on acf/init — do nothing if ACF is not active.
+	 */
+	public static function register(): void {
+		if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+			return;
+		}
+
+		acf_add_local_field_group(
+			array(
+				'key'                   => 'group_wt_airtable_sync_id',
+				'title'                 => 'Airtable Sync',
+				'fields'                => array(
+					array(
+						'key'           => 'field_wt_airtable_record_id',
+						'label'         => 'Airtable Record ID',
+						'name'          => '_airtable_record_id',
+						'type'          => 'text',
+						'instructions'  => 'Set automatically by the Airtable sync. Do not edit manually.',
+						'required'      => 0,
+						'wrapper'       => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'default_value' => '',
+						'placeholder'   => '',
+						'prepend'       => '',
+						'append'        => '',
+						'maxlength'     => '',
+						'readonly'      => 1,
+					),
+				),
+				'location'              => array(
+					array(
+						array(
+							'param'    => 'post_type',
+							'operator' => '==',
+							'value'    => 'languages',
+						),
+					),
+				),
+				'menu_order'            => 100,
+				'position'              => 'side',
+				'style'                 => 'default',
+				'label_placement'       => 'top',
+				'instruction_placement' => 'label',
+				'hide_on_screen'        => array(),
+				'active'                => true,
+				'description'           => 'Read-only Airtable sync metadata. Managed by the wt-airtable-sync plugin.',
+			)
+		);
+	}
+}

--- a/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
+++ b/wp-content/plugins/wt-airtable-sync/wt-airtable-sync.php
@@ -25,6 +25,7 @@ require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-logger.php';
 require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-field-resolver.php';
 require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-sync-controller.php';
 require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-sync-api.php';
+require_once WT_AIRTABLE_SYNC_DIR . 'includes/class-acf-fields.php';
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( __FILE__, __NAMESPACE__ . '\deactivate' );
@@ -73,3 +74,8 @@ add_action(
 		( new Sync_API() )->register_routes();
 	}
 );
+
+/**
+ * Register programmatic ACF field groups once ACF is ready.
+ */
+add_action( 'acf/init', __NAMESPACE__ . '\ACF_Fields::register' );


### PR DESCRIPTION
## Summary

- Registers a programmatic ACF local field group (`acf/init`) inside the plugin
- Exposes `_airtable_record_id` as a read-only text field in the **Languages** post edit sidebar
- Gracefully no-ops if ACF is not active (guards on `function_exists( 'acf_add_local_field_group' )`)

## Why

Gives editors visibility into which posts have been synced from Airtable — and what their Airtable record ID is — without needing database access. Useful for debugging sync state.

## Test plan

- [ ] Open any language post in WP admin
- [ ] Confirm "Airtable Sync" metabox appears in the sidebar with the Airtable Record ID value
- [ ] Confirm the field is read-only (cannot be edited)
- [ ] Confirm a language post that has not been synced shows an empty field (not an error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)