### PR TITLE
Fix deploy workflow: npm ci, StrictHostKeyChecking, health check, Slack

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Compile Stylus
         run: npm run stylus:build
@@ -40,7 +40,36 @@ jobs:
         run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy via rsync
-        run: rsync -avz -e "ssh -o StrictHostKeyChecking=no" --filter='merge .rsync-filter' . ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:${{ env.REMOTE_DIR }}
+        run: rsync -avz -e "ssh" --filter='merge .rsync-filter' . ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:${{ env.REMOTE_DIR }}
 
-      - name: Clean up known hosts
-        run: rm -f ~/.ssh/known_hosts
+      - name: Health check — confirm homepage returns 200
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" https://wikitongues.org)
+          echo "Homepage status: $status"
+          [ "$status" -eq 200 ] || { echo "ERROR: Homepage returned $status after deploy"; exit 1; }
+
+      - name: Notify Slack on success
+        if: success()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": ":rocket: Production deploy complete.",
+              "username": "GitHub Actions",
+              "icon_emoji": ":rocket:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": ":x: *Production deploy failed!*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View logs>",
+              "username": "GitHub Actions",
+              "icon_emoji": ":rotating_light:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

Four fixes to `deploy-production.yml`:

1. **`npm install` → `npm ci`** — strict lockfile, consistent with `lint.yml`
2. **Remove `StrictHostKeyChecking=no`** — `ssh-keyscan` already populates `known_hosts`; bypassing the check made that step pointless and introduced a mild MITM risk
3. **Add post-deploy health check** — curl the homepage after rsync; fail the job if it returns non-200, surfacing broken deploys immediately
4. **Add Slack notifications** — success (`:rocket:`) and failure (`:rotating_light:`) on every deploy, consistent with other workflows

Also removed the redundant `Clean up known hosts` step — Actions runners are ephemeral and cleaned up automatically.

## Test plan

- [ ] Trigger a deploy and confirm Slack notification fires
- [ ] Confirm homepage health check passes
- [ ] Confirm rsync connects without `StrictHostKeyChecking=no`

🤖 Generated with [Claude Code](https://claude.com/claude-code)