### PR TITLE
Add global fellowship about section to single fellows template

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -842,7 +842,7 @@ parameters:
 
 		-
 			message: "#^Function get_field not found\\.$#"
-			count: 9
+			count: 12
 			path: wp-content/themes/blankslate-child/single-fellows.php
 
 		-

--- a/wp-content/themes/blankslate-child/acf-json/group_69a8cf4582908.json
+++ b/wp-content/themes/blankslate-child/acf-json/group_69a8cf4582908.json
@@ -1,0 +1,105 @@
+{
+    "key": "group_69a8cf4582908",
+    "title": "Global: Fellowship Settings",
+    "fields": [
+        {
+            "key": "field_69a8d329396f1",
+            "label": "Display About",
+            "name": "display_about",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_69a8d1a8946e4",
+            "label": "Fellowship About Header",
+            "name": "fellowship_about_header",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_69a8d329396f1",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "allow_in_bindings": 0,
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_69a8cf45708c1",
+            "label": "Fellowship About",
+            "name": "fellowship_about",
+            "aria-label": "",
+            "type": "wysiwyg",
+            "instructions": "",
+            "required": 1,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_69a8d329396f1",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "allow_in_bindings": 0,
+            "tabs": "all",
+            "toolbar": "full",
+            "media_upload": 1,
+            "delay": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "options_page",
+                "operator": "==",
+                "value": "global-fellowship"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "display_title": "",
+    "modified": 1772671948
+}

--- a/wp-content/themes/blankslate-child/acf-json/ui_options_page_69a8cf1e45f96.json
+++ b/wp-content/themes/blankslate-child/acf-json/ui_options_page_69a8cf1e45f96.json
@@ -1,0 +1,23 @@
+{
+    "key": "ui_options_page_69a8cf1e45f96",
+    "title": "Global: Fellowship",
+    "active": true,
+    "menu_order": 0,
+    "page_title": "Global: Fellowship",
+    "menu_slug": "global-fellowship",
+    "parent_slug": "edit.php?post_type=fellows",
+    "advanced_configuration": 1,
+    "icon_url": "",
+    "menu_title": "Fellowship Settings",
+    "position": "",
+    "redirect": false,
+    "description": "",
+    "menu_icon": [],
+    "update_button": "Update",
+    "updated_message": "Options Updated",
+    "capability": "edit_posts",
+    "data_storage": "options",
+    "post_id": "",
+    "autoload": 0,
+    "modified": 1772671763
+}

--- a/wp-content/themes/blankslate-child/single-fellows.php
+++ b/wp-content/themes/blankslate-child/single-fellows.php
@@ -46,6 +46,19 @@ echo wpautop( wp_kses_post( $fellow_bio ) );
 echo wpautop( wp_kses_post( get_the_content() ) );
 echo '</div>';
 require 'modules/editorial-content.php';
+echo '<div class="main-content">';
+$display_about           = get_field( 'display_about', 'option' );
+$fellowship_about        = get_field( 'fellowship_about', 'option' );
+$fellowship_about_header = get_field( 'fellowship_about_header', 'option' );
+if ( $display_about && $fellowship_about ) {
+	echo '<div class="fellowship-about">';
+	echo '<strong class="wt_sectionHeader">' . esc_html( $fellowship_about_header ) . '</strong>';
+	echo wp_kses_post( $fellowship_about );
+	echo '</div>';
+}
+echo '</div>';
+// require 'modules/editorial-content.php';
+
 
 ?>
 <div class="custom-gallery full">


### PR DESCRIPTION
## Summary
- Adds new ACF options page **Global: Fellowship Settings** with three fields: `display_about` (boolean toggle), `fellowship_about_header` (text), and `fellowship_about` (WYSIWYG)
- Renders the about block on every single fellow page after editorial content, gated behind the `display_about` toggle
- ACF JSON synced for both the options page and field group

## Test plan
- [ ] Enable **Display About** in WP Admin → ACF Options → Fellowship Settings, fill in a header and body, verify the block appears on a single fellow page
- [ ] Disable the toggle, verify the block is hidden
- [ ] Verify the block does not render when `fellowship_about` content is empty even if toggle is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)