### PR TITLE
Mark Phase 3 items 4 and 5 complete in plan + archive

### DIFF
--- a/docs/plan-archive.md
+++ b/docs/plan-archive.md
@@ -5,6 +5,37 @@ Each entry includes branch, PR, merge commit, and a summary of what was done.
 
 ---
 
+## 2026-03-05 (Phase 3 items 4–5)
+
+### Phase 3 item 4 — Reorganize theme `includes/` into subdirectories + autoloader
+**Branch:** `chore/cc/reorganize-includes`
+**PR:** [#529](https://github.com/wikitongues/wikitongues.org/pull/529)
+
+Reorganized the flat `includes/` directory (24 files) into subdirectories by concern and replaced the manual `require_once` list in `functions.php` with a directory-scanning autoloader:
+
+- `admin/` — `admin-helpers.php`, `batch-operations.php`
+- `api/` — `rest-endpoints.php`
+- `integrations/` — `acf-helpers.php`, `document-download-handler.php`, `events-filter.php`
+- `taxonomies/` — all CPT/taxonomy registration files (moved from `custom-post-types/`)
+- `template/` — `enqueue-scripts.php`, `menus.php`, `router.php`, `search-filter.php`, `template-helpers.php`
+
+Also deleted one-time migration tools now superseded by Make.com: `import-captions.php` (+ its 44 unit tests) and `wp-cli-import.php`. Removed stale PHPStan baseline entries for both deleted files.
+
+### Phase 3 item 5 — CPT/taxonomy file consistency refactor
+**Branch:** `chore/cc/reorganize-includes`
+**PR:** [#529](https://github.com/wikitongues/wikitongues.org/pull/529)
+
+After moving all CPT files to `includes/taxonomies/`, cross-file audit and fixes:
+
+- Created missing CPT files: `blogs.php`, `careers.php`, `events.php` (previously inlined in `functions.php`)
+- Refactored `careers.php` from a class to plain functions; removed dead `register_acf_fields()` method
+- Fixed textdomains: `blogs.php` wrapped bare strings in `__()`, `events.php`/`faq.php` changed `'textdomain'` to CPT slug
+- Fixed wrong comment in `events.php` ("Register Custom Post Type for FAQs")
+- Added `taxonomies` key to `reports.php` to match other CPT registrations
+- Remaining security items (XSS in `faq.php`, null-deref in `documents.php`) tracked as separate work
+
+---
+
 ## 2026-03-05 (Phase 3 items 2–3 + Infrastructure + Features)
 
 ### Phase 3 item 3 — Remove dead post-object-helpers / REST controller chain

--- a/plan.md
+++ b/plan.md
@@ -78,25 +78,16 @@ Weekly automated sync via `backup-prod-db.yml` → `sync-prod-to-staging.yml`. R
 
 Deleted `post-object-helpers.php` (both copies), `class-wt-rest-posts-controller.php`, removed `rest_controller_class` from 7 CPTs, cleared root `includes/` directory (PR #520).
 
-#### 4. Reorganize theme `includes/` into subdirectories + autoloader _(combines former C + D)_
+#### 4. ~~Reorganize theme `includes/` into subdirectories + autoloader~~ ✅
 
-Currently 24 flat files. Reorganize into subdirectories by concern and replace the manual `require_once` list in `functions.php` with a directory-scanning autoloader in one pass:
-- `api/` — REST endpoints, controller
-- `admin/` — admin helpers, batch operations
-- `taxonomies/` — CPT and taxonomy registration
-- `template/` — template helpers, router
-- `integrations/` — import-captions, events filter, license handling
+See [archive](docs/plan-archive.md) (PR #529).
 
-#### 5. CPT/taxonomy file consistency refactor _(follows reorganize-includes)_
+#### 5. ~~CPT/taxonomy file consistency refactor~~ ✅ _(partial — security items below outstanding)_
 
-After moving all CPT files to `includes/taxonomies/`, a cross-file audit found several inconsistencies:
+Pattern, i18n, and structural issues resolved (PR #529). Remaining:
 
 - **Security:** `faq.php` — `echo $terms` unescaped in column handler (XSS); `get_the_title()` unescaped in shortcode output. `documents.php` — `->post_title` accessed on return value of `get_field()` without null check (fatal if field empty).
-- **Pattern:** `careers.php` uses a class instead of plain functions; has dead `register_acf_fields()` method (never hooked); textdomain is `'textdomain'`.
-- **Missing args:** `fellows.php` missing `show_in_rest`; missing `is_main_query()` guard in orderby callback; has commented-out block. `reports.php` missing `show_in_rest`.
-- **Redundant:** `reports.php` and `team.php` both call `register_taxonomy_for_object_type()` AND pass `'taxonomies'` arg — pick one (keep `register_taxonomy_for_object_type()` to match languages/videos).
-- **i18n:** `blogs.php` uses bare strings with no `__()` wrapping; `events.php` and `faq.php` use `'textdomain'` instead of the CPT slug.
-- **Wrong comment:** `events.php` comment says "Register Custom Post Type for FAQs".
+- **Missing args:** `fellows.php` missing `show_in_rest`; missing `is_main_query()` guard in orderby callback; has commented-out block.
 
 #### 6. Archive template refactor _(before Docker)_
 


### PR DESCRIPTION
## Summary

- Marks Phase 3 items 4 (reorganize includes) and 5 (CPT consistency refactor) as complete in `plan.md`
- Adds archive entries for both to `docs/plan-archive.md`
- Keeps outstanding security items (XSS in `faq.php`, null-deref in `documents.php`, `fellows.php` missing args) visible in plan.md as remaining work

## Test plan

- [ ] Verify `plan.md` items 4 and 5 show ✅
- [ ] Verify archive entry matches PR #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)