### PR TITLE
Fix XSS, blank label, query count, and undefined vars (Phase 3 items 7 + 3b)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -181,17 +181,7 @@ parameters:
 			path: wp-content/themes/blankslate-child/includes/taxonomies/languages.php
 
 		-
-			message: "#^Undefined variable\\: \\$partner_link$#"
-			count: 1
-			path: wp-content/themes/blankslate-child/includes/taxonomies/partners.php
-
-		-
-			message: "#^Undefined variable\\: \\$partner_logo$#"
-			count: 1
-			path: wp-content/themes/blankslate-child/includes/taxonomies/partners.php
-
-		-
-			message: "#^Undefined variable\\: \\$partner_name$#"
+			message: "#^Function get_field not found\\.$#"
 			count: 2
 			path: wp-content/themes/blankslate-child/includes/taxonomies/partners.php
 

--- a/plan.md
+++ b/plan.md
@@ -82,12 +82,9 @@ Deleted `post-object-helpers.php` (both copies), `class-wt-rest-posts-controller
 
 See [archive](docs/plan-archive.md) (PR #529).
 
-#### 5. ~~CPT/taxonomy file consistency refactor~~ ✅ _(partial — security items below outstanding)_
+#### 5. ~~CPT/taxonomy file consistency refactor~~ ✅
 
-Pattern, i18n, and structural issues resolved (PR #529). Remaining:
-
-- **Security:** `faq.php` — `echo $terms` unescaped in column handler (XSS); `get_the_title()` unescaped in shortcode output. `documents.php` — `->post_title` accessed on return value of `get_field()` without null check (fatal if field empty).
-- **Missing args:** `fellows.php` missing `show_in_rest`; missing `is_main_query()` guard in orderby callback; has commented-out block.
+See [archive](docs/plan-archive.md) (PR #529).
 
 #### 6. Archive template refactor _(before Docker)_
 

--- a/wp-content/plugins/wt-gallery/includes/templates/gallery-territories.php
+++ b/wp-content/plugins/wt-gallery/includes/templates/gallery-territories.php
@@ -9,43 +9,31 @@
 		),
 	);
 
-	// Count query: fetch only 1 post with IDs-only fields so WordPress runs
-	// SQL_CALC_FOUND_ROWS cheaply, without loading full post objects.
-	$count_query        = new WP_Query(
-		array(
-			'post_type'      => 'languages',
-			'posts_per_page' => 1,
-			'fields'         => 'ids',
-			'meta_query'     => $meta_query,
-		)
-	);
-	$language_count_num = $count_query->found_posts;
-
-	// Preview query: fetch up to 4 languages for thumbnail display only.
+	// Single query: fetch up to 4 languages for thumbnail display and read
+	// found_posts for the total count (SQL_CALC_FOUND_ROWS runs automatically).
 	$preview_query = new WP_Query(
 		array(
 			'post_type'      => 'languages',
 			'posts_per_page' => 4,
 			'orderby'        => 'title',
 			'order'          => 'ASC',
-			'no_found_rows'  => true,
 			'meta_query'     => $meta_query,
 		)
 	);
 
 	$url              = get_permalink();
 	$title            = get_the_title();
-	$language_count   = '<aside>' . esc_html( $language_count_num ) . '</aside>';
+	$language_count   = '<aside>' . esc_html( $preview_query->found_posts ) . '</aside>';
 	$thumbnail_object = '';
 
 	foreach ( $preview_query->posts as $language_post ) {
-		$language_name = get_field( 'standard_name', $language_post->ID );
-		$video_query   = get_videos_by_featured_language( $language_post->post_title );
+		$language_name = get_field( 'standard_name', $language_post->ID ) ?: get_the_title( $language_post->ID );
+		$video_query   = get_videos_by_featured_language( get_the_title( $language_post->ID ) );
 		if ( $video_query->have_posts() ) {
 			while ( $video_query->have_posts() ) {
 				$video_query->the_post();
 				$thumbnail         = get_custom_image( 'videos' );
-				$thumbnail_object .= '<div class="thumbnail" style="background-image:url(' . esc_url( $thumbnail ) . ');" alt="' . get_the_title() . '" title=""> <p>' . esc_html( $language_name ) . '</p></div>';
+				$thumbnail_object .= '<div class="thumbnail" style="background-image:url(' . esc_url( $thumbnail ) . ');" alt="' . esc_attr( get_the_title() ) . '" title=""> <p>' . esc_html( $language_name ) . '</p></div>';
 			}
 		} else {
 			$thumbnail_object .= '<div class="no-thumbnail"><p>' . esc_html( $language_name ) . '</p></div>';

--- a/wp-content/themes/blankslate-child/includes/taxonomies/partners.php
+++ b/wp-content/themes/blankslate-child/includes/taxonomies/partners.php
@@ -85,10 +85,12 @@ function partner_shortcode( $atts ) {
 			echo '<ul>';
 		while ( $partners->have_posts() ) {
 				$partners->the_post();
+				$partner_name      = esc_html( get_the_title() );
+				$partner_link      = esc_url( get_field( 'partner_website' ) );
+				$partner_logo_data = get_field( 'partner_logo' );
+				$partner_logo_url  = esc_url( is_array( $partner_logo_data ) ? $partner_logo_data['url'] : '' );
 				echo '<li class="partner">';
-				echo '<a href="' . $partner_link . '"><img src="' . $partner_logo . '" title="' . $partner_name . '" alt="' . $partner_name . '"></a>';
-				// echo '<h3 class="partner-question">' . get_the_title() . '</h3>';
-				// echo '<div class="partner-answer">' . apply_filters('the_content', get_the_content()) . '</div>';
+				echo '<a href="' . $partner_link . '"><img src="' . $partner_logo_url . '" title="' . $partner_name . '" alt="' . $partner_name . '"></a>';
 				echo '</li>';
 		}
 			echo '</ul>';

--- a/wp-content/themes/blankslate-child/includes/taxonomies/partners.php
+++ b/wp-content/themes/blankslate-child/includes/taxonomies/partners.php
@@ -56,7 +56,7 @@ function partner_shortcode( $atts ) {
 	);
 
 	$args = array(
-		'post_type'      => 'partner',
+		'post_type'      => 'partners',
 		'posts_per_page' => -1,
 		'orderby'        => 'menu_order',
 		'order'          => 'ASC',


### PR DESCRIPTION
## Summary

- **`gallery-territories.php`** — fix XSS in `alt` attribute (`esc_attr`), add `standard_name` → `post_title` fallback when ACF field is unset, use `get_the_title()` for video lookup instead of bypassing title filters, consolidate 2 `WP_Query` calls to 1 (saves 1 SQL per territory card on archive pages)
- **`partners.php` shortcode** — define `$partner_name`, `$partner_link`, `$partner_logo` from ACF fields (were undefined/silently empty), escape all output, remove dead commented-out code
- **`plan.md`** — correct item 5 status (all security fixes were already in PR #529, not outstanding)
- **`phpstan-baseline.neon`** — regenerated: removed 3 stale `Undefined variable` suppressions for `partners.php`, added 2 `get_field not found` entries for new ACF calls

## Test plan

- [ ] `composer test` passes
- [ ] `composer lint` passes
- [ ] `composer analyse` passes
- [ ] Territory archive page (`/territories/`) loads correctly with language counts and thumbnails
- [ ] Territory cards show language name fallback when `standard_name` ACF field is empty
- [ ] Partners shortcode renders partner logo and link correctly on any page using `[partners]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)