### PR TITLE
Add wt_gallery_params() helper across all gallery call sites (Phase 3 item 6)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"bmewburn.vscode-intelephense"
+	]
+}

--- a/docs/gallery-inventory-main.csv
+++ b/docs/gallery-inventory-main.csv
@@ -1,0 +1,30 @@
+file,condition,title,post_type,custom_class,columns,posts_per_page,show_total,orderby,order,pagination,meta_key,meta_value,selected_posts,display_blank,exclude_self,taxonomy,term,subtitle,link_out
+archive-fellows.php,?territory or ?region (fellows found),Fellows from {territory/region},fellows,,5,100,true,title,asc,true,,,{fellow IDs},false,false,,,,,
+archive-fellows.php,?territory or ?region (no fellows),Fellows from {territory/region},fellows,,5,100,true,title,asc,true,,,-1,true,false,,,,,
+archive-fellows.php,no filter,Fellows,fellows,,5,100,true,title,asc,true,,,,false,false,,,,/revitalization/fellows
+archive-languages.php,?territory,Languages of {territory},languages,,5,100,true,title,asc,true,,,{language IDs},true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,?genealogy,{genealogy} linguistic family,languages,,5,100,true,title,asc,true,,,,true,false,,linguistic-genealogy,{slug},"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,?writing_system,Languages written in {system} / Unwritten languages,languages,,5,100,true,title,asc,true,,,,true,false,,writing-system,{slug},"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,no filter,Languages,languages,,5,100,true,title,asc,true,,,,false,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-videos.php,?language,{language} videos,videos,,5,100,true,date,desc,true,featured_languages,{language ID},,true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-videos.php,no filter,Videos,videos,,5,100,true,date,desc,true,,,,false,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-territories.php,?region,Territories of {region},territories,,5,100,true,title,asc,true,,,,true,false,,region,{slug},,
+archive-territories.php,no filter,Territories,territories,,5,100,true,title,asc,true,,,,false,false,,,,
+single-territories.php,if fellows linked,Fellows from {territory},fellows,,3,3,true,title,asc,true,,,{fellow IDs},false,false,,,,,{/fellows?territory=slug}
+single-territories.php,always,Languages of {territory},languages,,3,6,true,{language IDs},asc,true,,,{language IDs},true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",{/languages?territory=slug}
+single-languages.php,if territories linked,Other languages from {territories},languages,full,5,5,true,rand,asc,true,,,{language IDs},false,true,,,,,{/languages?territory=slug or ''}
+single-videos.php,always,Other videos of {languages},videos,full,5,5,false,rand,asc,false,featured_languages,{language IDs},,false,true,,,,,
+single-fellows.php,always,,fellows,full,4,4,false,rand,,false,fellow_year,{year},,false,true,,,,,
+taxonomy-region.php,if fellows linked,Fellows from {region},fellows,,3,3,true,title,asc,true,,,{fellow IDs},false,false,,,,,{/fellows?region=slug}
+taxonomy-region.php,always,Territories in {region},territories,,3,9,true,title,asc,true,,,{territory IDs (continent) or ''},true,false,,{region or ''},{slug or ''},{/territories?region=slug}
+taxonomy-fellow-category.php,always,,fellows,full,4,'50',false,year,desc,true,,,,true,false,,fellow-category,{slug},,
+template-revitalization-fellows.php,always,,fellows,full,4,60,false,rand,,true,fellow_year,{year or cohorts[0]},,false,true,,,,,
+template-about-staff.php,always,Explore careers,careers,,1,3,,rand,asc,false,,,,false,true,,career_type,Staff,,
+template-about-staff.php,always,Explore other opportunities,careers,,1,3,,rand,asc,false,,,,false,true,,career_type,"Intern,Volunteer",,
+modules/languages/single-languages__videos.php,always,{language} videos,videos,,3,6,true,date,asc,true,featured_languages,{language ID},,true,true,,,,"Wikitongues crowd-sources video samples of every language in the world.",{/videos?language=slug}
+modules/languages/single-languages__fellows.php,if fellows linked,{language} Revitalization Projects,fellows,display,1,1,false,date,asc,true,fellow_language,{language ID},,false,true,,,,The Wikitongues Fellowship is an accelerator program where activists can learn from a network of revitalization projects.,
+modules/languages/single-languages__lexicons.php,always,{language} to other languages,lexicons,,3,6,false,date,asc,true,source_languages,{language ID},,true,true,,,,,
+modules/languages/single-languages__lexicons.php,always,Other languages to {language},lexicons,,3,6,false,date,asc,true,target_languages,{language ID},,true,true,,,,,
+modules/languages/single-languages__resources.php,always,{language} external resources,resources,,3,6,false,date,asc,true,resource_language,{language ID},,true,true,,,,Wikitongues indexes language resources from across the internet.,
+template-giving-campaign-24.php,always,{ACF sub-field},fellows,"custom fundraiser",1,5,false,rand,asc,false,,,{selected IDs},false,true,,,,,
+modules/flexible-content/gallery-layout.php,per row (loop),{ACF sub-field},{ACF sub-field},full,{ACF sub-field},{ACF sub-field},false,rand,asc,{ACF sub-field},,,{selected IDs},false,true,,,,,

--- a/docs/gallery-inventory.csv
+++ b/docs/gallery-inventory.csv
@@ -1,0 +1,30 @@
+file,condition,title,post_type,custom_class,columns,posts_per_page,show_total,orderby,order,pagination,meta_key,meta_value,selected_posts,display_blank,exclude_self,taxonomy,term,subtitle,link_out
+archive-fellows.php,?territory or ?region (fellows found),Fellows from {territory/region},fellows,,5,100,true,title,asc,true,,,{fellow IDs},false,false,,,,,
+archive-fellows.php,?territory or ?region (no fellows),Fellows from {territory/region},fellows,,5,100,true,title,asc,true,,,-1,true,false,,,,,
+archive-fellows.php,no filter,Fellows,fellows,,5,100,true,title,asc,true,,,,false,false,,,,/revitalization/fellows
+archive-languages.php,?territory,Languages of {territory},languages,,5,100,true,title,asc,true,,,{language IDs},true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,?genealogy,{genealogy} linguistic family,languages,,5,100,true,title,asc,true,,,,true,false,,linguistic-genealogy,{slug},"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,?writing_system,Languages written in {system} / Unwritten languages,languages,,5,100,true,title,asc,true,,,,true,false,,writing-system,{slug},"Wikitongues crowd-sources video samples of every language in the world.",
+archive-languages.php,no filter,Languages,languages,,5,100,true,title,asc,true,,,,false,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-videos.php,?language,{language} videos,videos,,5,100,true,date,desc,true,featured_languages,{language ID},,true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-videos.php,no filter,Videos,videos,,5,100,true,date,desc,true,,,,false,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",
+archive-territories.php,?region,Territories of {region},territories,,5,100,true,title,asc,true,,,,true,false,,region,{slug},,
+archive-territories.php,no filter,Territories,territories,,5,100,true,title,asc,true,,,,false,false,,,,
+single-territories.php,if fellows linked,Fellows from {territory},fellows,,3,3,true,title,asc,true,,,{fellow IDs},false,false,,,,,{/fellows?territory=slug}
+single-territories.php,always,Languages of {territory},languages,,3,6,true,{language IDs},asc,true,,,{language IDs},true,false,,,,"Wikitongues crowd-sources video samples of every language in the world.",{/languages?territory=slug}
+single-languages.php,if territories linked,Other languages from {territories},languages,full,5,5,true,rand,asc,true,,,{language IDs},false,true,,,,,{/languages?territory=slug or ''}
+single-videos.php,always,Other videos of {languages},videos,full,5,5,false,rand,asc,false,featured_languages,{language IDs},,false,true,,,,,
+single-fellows.php,always,,fellows,full,4,4,false,rand,,false,fellow_year,{year},,false,true,,,,,
+taxonomy-region.php,if fellows linked,Fellows from {region},fellows,,3,3,true,title,asc,true,,,{fellow IDs},false,false,,,,,{/fellows?region=slug}
+taxonomy-region.php,always,Territories in {region},territories,,3,9,true,title,asc,true,,,{territory IDs (continent) or ''},true,false,,{region or ''},{slug or ''},{/territories?region=slug}
+taxonomy-fellow-category.php,always,,fellows,full,4,50,false,year,desc,true,,,,true,false,,fellow-category,{slug},,
+template-revitalization-fellows.php,always,,fellows,full,4,60,false,rand,,true,fellow_year,{year or cohorts[0]},,false,true,,,,,
+template-about-staff.php,always,Explore careers,careers,,1,3,true,rand,asc,false,,,,false,true,,career_type,Staff,,
+template-about-staff.php,always,Explore other opportunities,careers,,1,3,true,rand,asc,false,,,,false,true,,career_type,"Intern,Volunteer",,
+modules/languages/single-languages__videos.php,always,{language} videos,videos,,3,6,true,date,asc,true,featured_languages,{language ID},,true,true,,,,"Wikitongues crowd-sources video samples of every language in the world.",{/videos?language=slug}
+modules/languages/single-languages__fellows.php,if fellows linked,{language} Revitalization Projects,fellows,display,1,1,false,date,asc,true,fellow_language,{language ID},,false,true,,,,The Wikitongues Fellowship is an accelerator program where activists can learn from a network of revitalization projects.,
+modules/languages/single-languages__lexicons.php,always,{language} to other languages,lexicons,,3,6,false,date,asc,true,source_languages,{language ID},,true,true,,,,,
+modules/languages/single-languages__lexicons.php,always,Other languages to {language},lexicons,,3,6,false,date,asc,true,target_languages,{language ID},,true,true,,,,,
+modules/languages/single-languages__resources.php,always,{language} external resources,resources,,3,6,false,date,asc,true,resource_language,{language ID},,true,true,,,,Wikitongues indexes language resources from across the internet.,
+template-giving-campaign-24.php,always,{ACF sub-field},fellows,"custom fundraiser",1,5,false,rand,asc,false,,,{selected IDs},false,true,,,,,
+modules/flexible-content/gallery-layout.php,per row (loop),{ACF sub-field},{ACF sub-field},full,{ACF sub-field},{ACF sub-field},false,rand,asc,{ACF sub-field},,,{selected IDs},false,true,,,,,

--- a/plan.md
+++ b/plan.md
@@ -100,6 +100,8 @@ See [archive](docs/plan-archive.md) (PR #529).
 
 `archive-languages.php`, `archive-fellows.php`, `archive-videos.php` share a structural pattern with boilerplate repeated across files. Evaluate a shared archive helper or declarative config approach. `archive-donors.php` intentionally does NOT use `create_gallery_instance()` — out of scope.
 
+**PHPDoc array shapes** — `wt_gallery_params()` now carries full `@param`/`@return` array shape annotations (PHPStan + IDE autocomplete). Evaluate applying this pattern consistently to other helper functions across the project: `wt_social_links()`, `wt_archive_params()` callers, any function accepting or returning a structured array. Goal: callers should never need to open a function definition to know its contract.
+
 #### 7. `gallery-territories.php` + `archive-territories.php` fixes _(combines former F + G)_
 
 **`gallery-territories.php`:**

--- a/plan.md
+++ b/plan.md
@@ -133,6 +133,58 @@ Weekly WP-CLI command (`wp wt integrity check`) against the live DB. See [docs/t
 
 Replace the basic search results page with a gallery-powered page surfacing results across languages, territories, linguistic genealogy, writing system, videos, and fellows. Evaluate `create_gallery_instance()` in multi-type mode or a dedicated query-and-render pattern.
 
+#### 12. Airtable sync — Slack change notifications _(parallel; no deps)_
+
+Two-part feature: plugin returns a field-level diff in the sync response; Make.com posts a Slack message when the diff is non-empty or a new record is created.
+
+**Part 1 — Plugin: changed-fields diff in sync response**
+
+Add a diff step to `Sync_Controller::sync()` in `wt-airtable-sync`:
+
+1. Before writing, read the current stored value of each mapped field via `get_field()` / `get_post_meta()`.
+2. After resolving incoming values (same logic as `write_meta()`), compare old vs new.
+3. Exclude fields where old and new are identical — no write-without-change noise.
+4. Return a `changed` key in the live-write response alongside the existing fields:
+
+```json
+{
+  "status": "ok",
+  "action": "updated",
+  "post_id": 12345,
+  "post_title": "Polynesian",
+  "changed": {
+    "public_status": { "old": "draft", "new": "publish" },
+    "featured_languages": { "old": [42], "new": [42, 87] }
+  }
+}
+```
+
+For `created` records, `changed` lists all written values with `"old": null`. `video_thumbnail_v2` (attachment ID) is excluded from the diff — its changes are implicit when the thumbnail module runs.
+
+**Part 2 — Make.com: Slack module with human-readable diff**
+
+Add a Slack module at the end of each scenario, after the sync POST:
+
+- **Gate:** only fire when `action == "created"` OR `changed` is non-empty. Skip entirely on unchanged updates.
+- **post_object resolution:** `changed` values for relationship fields are WP post IDs. Use a "Resolve WP Post" subscenario (see below) to convert them to titles before formatting the message.
+- **Message format:** `[Videos] Updated "Polynesian" — public_status: draft → publish | featured_languages: added "English"`
+- **Channel:** configurable in each scenario's SetVariables module (same pattern as `wp_base_url`).
+
+**"Resolve WP Post" subscenario pattern**
+
+Mirrors the Captions subscenarios that resolve Airtable linked record IDs. Instead of calling Airtable, call the standard WP REST API:
+
+```
+GET {{wp_base_url}}/wp-json/wp/v2/{post_type}/{id}?_fields=id,title
+```
+
+No custom endpoint required — the built-in WP REST API already exposes this. One subscenario per target CPT (languages, videos, etc.) or a single generic one parameterised by `post_type` + `id`. The auth keychain used for media uploads (basicAuth) is reused — no new credentials needed.
+
+**Scope boundaries:**
+- Only scalar text fields and resolved post_object titles in the notification — no binary/attachment diffs.
+- `video_thumbnail_v2` excluded from diff display.
+- Staging and production scenario instances each notify their own channel (same per-environment convention as `wp_base_url`).
+
 ---
 
 ### Phase 3b — PHPStan baseline reduction _(concurrent with Phase 3 and beyond)_

--- a/plan.md
+++ b/plan.md
@@ -8,6 +8,16 @@ Completed work: [plan-archive.md](docs/plan-archive.md) | Testing strategy: [doc
 ## Table of Contents
 
 - [Roadmap](#roadmap)
+- [~~Phase 1~~](#phase-1--security-foundation-)
+- [~~Phase 2~~](#phase-2--visual-infrastructure--plugin-hygiene-)
+- [Phase 3](#phase-3--code-quality--data-integrity-baseline)
+- [Phase 3b](#phase-3b--phpstan-baseline-reduction-)
+- [Phase 4](#phase-4--docker--gateway-core)
+- [Phase 5](#phase-5--integration-tests--airtable-reconciliation--gateway-completion)
+- [Phase 6](#phase-6--visual-baseline--data-migration)
+- [Phase 7](#phase-7--features-and-monitoring-requiring-the-visual-baseline)
+- [Phase 8](#phase-8--membership-dependent-features)
+- [Backlog](#backlog--known-issues-no-active-fix-timeline)
 
 ---
 
@@ -283,12 +293,6 @@ No visibility into page load times or query performance in production. Known ris
 
 ---
 
-### Backlog — known issues, no active fix timeline
-
-- **Fellows meta query scales poorly on continent pages** — `taxonomy-region.php` builds an OR `meta_query` with one LIKE clause per territory (Asia: 215 territories). Not currently failing (`memory_limit = -1` on local and production) but would exhaust a 128 MB limit. [Issue #533](https://github.com/wikitongues/wikitongues.org/issues/533)
-
----
-
 ### Phase 8 — Membership-dependent features
 
 _Blocked on membership infrastructure (user accounts), which is not currently in scope. Write a spec before implementation._
@@ -296,3 +300,9 @@ _Blocked on membership infrastructure (user accounts), which is not currently in
 #### Gamification
 
 Stamp rally: users earn stamps for core actions (watch a video, add a language, share a page). Onboarding flow guides new users through first actions. Matches the Wikitongues travel/documentation brand. Hard dependency: membership infrastructure. Write a separate spec before implementation.
+
+---
+
+### Backlog — known issues, no active fix timeline
+
+- **Fellows meta query scales poorly on continent pages** — `taxonomy-region.php` builds an OR `meta_query` with one LIKE clause per territory (Asia: 215 territories). Not currently failing (`memory_limit = -1` on local and production) but would exhaust a 128 MB limit. [Issue #533](https://github.com/wikitongues/wikitongues.org/issues/533)

--- a/wp-content/themes/blankslate-child/archive-fellows.php
+++ b/wp-content/themes/blankslate-child/archive-fellows.php
@@ -1,12 +1,10 @@
 <?php
 get_header();
 
-$territory_slug         = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
-$territory_post         = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
-$region_slug            = isset( $_GET['region'] ) ? sanitize_title( wp_unslash( $_GET['region'] ) ) : '';
-$region_term            = $region_slug ? get_term_by( 'slug', $region_slug, 'region' ) : null;
-$archive_columns        = 5;
-$archive_posts_per_page = 100;
+$territory_slug = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
+$territory_post = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
+$region_slug    = isset( $_GET['region'] ) ? sanitize_title( wp_unslash( $_GET['region'] ) ) : '';
+$region_term    = $region_slug ? get_term_by( 'slug', $region_slug, 'region' ) : null;
 
 echo '<main class="wt_archive-fellows">';
 
@@ -32,44 +30,21 @@ if ( $territory_post ) {
 	if ( $fellows_query->have_posts() ) {
 		$fellow_ids = wp_list_pluck( $fellows_query->posts, 'ID' );
 		wp_reset_postdata();
-		$params = array(
-			'title'          => 'Fellows from ' . $territory_name,
-			'subtitle'       => '',
-			'show_total'     => 'true',
-			'post_type'      => 'fellows',
-			'columns'        => $archive_columns,
-			'posts_per_page' => $archive_posts_per_page,
-			'orderby'        => 'title',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => implode( ',', $fellow_ids ),
-			'display_blank'  => 'false',
-			'exclude_self'   => 'false',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => 'Fellows from ' . $territory_name,
+				'post_type'      => 'fellows',
+				'selected_posts' => implode( ',', $fellow_ids ),
+			)
 		);
 	} else {
-		$params = array(
-			'title'          => 'Fellows from ' . $territory_name,
-			'subtitle'       => '',
-			'show_total'     => 'true',
-			'post_type'      => 'fellows',
-			'columns'        => $archive_columns,
-			'posts_per_page' => $archive_posts_per_page,
-			'orderby'        => 'title',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => '-1',
-			'display_blank'  => 'true',
-			'exclude_self'   => 'false',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => 'Fellows from ' . $territory_name,
+				'post_type'      => 'fellows',
+				'selected_posts' => '-1',
+				'display_blank'  => 'true',
+			)
 		);
 	}
 	echo create_gallery_instance( $params );
@@ -127,89 +102,43 @@ if ( $territory_post ) {
 		if ( $region_fellows_query->have_posts() ) {
 			$fellow_ids = wp_list_pluck( $region_fellows_query->posts, 'ID' );
 			wp_reset_postdata();
-			$params = array(
-				'title'          => 'Fellows from ' . $region_name,
-				'subtitle'       => '',
-				'show_total'     => 'true',
-				'post_type'      => 'fellows',
-				'columns'        => $archive_columns,
-				'posts_per_page' => $archive_posts_per_page,
-				'orderby'        => 'title',
-				'order'          => 'asc',
-				'pagination'     => 'true',
-				'meta_key'       => '',
-				'meta_value'     => '',
-				'selected_posts' => implode( ',', $fellow_ids ),
-				'display_blank'  => 'false',
-				'exclude_self'   => 'false',
-				'taxonomy'       => '',
-				'term'           => '',
-				'link_out'       => '',
+			$params = wt_gallery_params(
+				array(
+					'title'          => 'Fellows from ' . $region_name,
+					'post_type'      => 'fellows',
+					'selected_posts' => implode( ',', $fellow_ids ),
+				)
 			);
 		} else {
 			wp_reset_postdata();
-			$params = array(
-				'title'          => 'Fellows from ' . $region_name,
-				'subtitle'       => '',
-				'show_total'     => 'true',
-				'post_type'      => 'fellows',
-				'columns'        => $archive_columns,
-				'posts_per_page' => $archive_posts_per_page,
-				'orderby'        => 'title',
-				'order'          => 'asc',
-				'pagination'     => 'true',
-				'meta_key'       => '',
-				'meta_value'     => '',
-				'selected_posts' => '-1',
-				'display_blank'  => 'true',
-				'exclude_self'   => 'false',
-				'taxonomy'       => '',
-				'term'           => '',
-				'link_out'       => '',
+			$params = wt_gallery_params(
+				array(
+					'title'          => 'Fellows from ' . $region_name,
+					'post_type'      => 'fellows',
+					'selected_posts' => '-1',
+					'display_blank'  => 'true',
+				)
 			);
 		}
 	} else {
 		wp_reset_postdata();
-		$params = array(
-			'title'          => 'Fellows from ' . $region_name,
-			'subtitle'       => '',
-			'show_total'     => 'true',
-			'post_type'      => 'fellows',
-			'columns'        => $archive_columns,
-			'posts_per_page' => $archive_posts_per_page,
-			'orderby'        => 'title',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => '-1',
-			'display_blank'  => 'true',
-			'exclude_self'   => 'false',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => 'Fellows from ' . $region_name,
+				'post_type'      => 'fellows',
+				'selected_posts' => '-1',
+				'display_blank'  => 'true',
+			)
 		);
 	}
 	echo create_gallery_instance( $params );
 } else {
-	$params = array(
-		'title'          => 'Fellows',
-		'subtitle'       => '',
-		'show_total'     => 'true',
-		'post_type'      => 'fellows',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => home_url( '/revitalization/fellows', 'relative' ),
+	$params = wt_gallery_params(
+		array(
+			'title'     => 'Fellows',
+			'post_type' => 'fellows',
+			'link_out'  => home_url( '/revitalization/fellows', 'relative' ),
+		)
 	);
 	echo create_gallery_instance( $params );
 }

--- a/wp-content/themes/blankslate-child/archive-languages.php
+++ b/wp-content/themes/blankslate-child/archive-languages.php
@@ -1,15 +1,16 @@
 <?php
 get_header();
 
-$territory_slug         = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
-$territory_post         = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
-$genealogy              = isset( $_GET['genealogy'] ) ? sanitize_text_field( wp_unslash( $_GET['genealogy'] ) ) : '';
-$genealogy_term         = $genealogy ? get_term_by( 'slug', $genealogy, 'linguistic-genealogy' ) : null;
-$writing_system         = isset( $_GET['writing_system'] ) ? sanitize_text_field( wp_unslash( $_GET['writing_system'] ) ) : '';
-$writing_system_term    = $writing_system ? get_term_by( 'slug', $writing_system, 'writing-system' ) : null;
-$archive_columns        = 5;
-$archive_posts_per_page = 100;
+$territory_slug      = isset( $_GET['territory'] ) ? sanitize_title( wp_unslash( $_GET['territory'] ) ) : '';
+$territory_post      = $territory_slug ? get_page_by_path( $territory_slug, OBJECT, 'territories' ) : null;
+$genealogy           = isset( $_GET['genealogy'] ) ? sanitize_text_field( wp_unslash( $_GET['genealogy'] ) ) : '';
+$genealogy_term      = $genealogy ? get_term_by( 'slug', $genealogy, 'linguistic-genealogy' ) : null;
+$writing_system      = isset( $_GET['writing_system'] ) ? sanitize_text_field( wp_unslash( $_GET['writing_system'] ) ) : '';
+$writing_system_term = $writing_system ? get_term_by( 'slug', $writing_system, 'writing-system' ) : null;
+
 echo '<main class="wt_archive-languages">';
+
+$subtitle = 'Wikitongues crowd-sources video samples of every language in the world.';
 
 if ( $territory_post ) {
 	$territory_name = wt_prefix_the( $territory_post->post_title );
@@ -17,84 +18,48 @@ if ( $territory_post ) {
 	$language_ids = get_field( 'languages', $territory_post->ID, false );
 	$selected     = $language_ids ? implode( ',', $language_ids ) : '';
 
-	$params = array(
-		'title'          => 'Languages of ' . $territory_name,
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => $selected,
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'          => 'Languages of ' . $territory_name,
+			'subtitle'       => $subtitle,
+			'post_type'      => 'languages',
+			'selected_posts' => $selected,
+			'display_blank'  => 'true',
+		)
 	);
 } elseif ( $genealogy_term ) {
-	$params = array(
-		'title'          => $genealogy_term->name . ' linguistic family',
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => 'linguistic-genealogy',
-		'term'           => $genealogy_term->slug,
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'         => $genealogy_term->name . ' linguistic family',
+			'subtitle'      => $subtitle,
+			'post_type'     => 'languages',
+			'display_blank' => 'true',
+			'taxonomy'      => 'linguistic-genealogy',
+			'term'          => $genealogy_term->slug,
+		)
 	);
 } elseif ( $writing_system_term ) {
-	$params = array(
-		'title'          => strtolower( $writing_system_term->name ) === 'unwritten' ? 'Unwritten languages' : 'Languages written in ' . $writing_system_term->name,
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => 'writing-system',
-		'term'           => $writing_system_term->slug,
-		'link_out'       => '',
+	$title = strtolower( $writing_system_term->name ) === 'unwritten'
+		? 'Unwritten languages'
+		: 'Languages written in ' . $writing_system_term->name;
+
+	$params = wt_gallery_params(
+		array(
+			'title'         => $title,
+			'subtitle'      => $subtitle,
+			'post_type'     => 'languages',
+			'display_blank' => 'true',
+			'taxonomy'      => 'writing-system',
+			'term'          => $writing_system_term->slug,
+		)
 	);
 } else {
-	$params = array(
-		'title'          => 'Languages',
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'     => 'Languages',
+			'subtitle'  => $subtitle,
+			'post_type' => 'languages',
+		)
 	);
 }
 

--- a/wp-content/themes/blankslate-child/archive-territories.php
+++ b/wp-content/themes/blankslate-child/archive-territories.php
@@ -1,53 +1,28 @@
 <?php
 get_header();
 
-$region_slug            = isset( $_GET['region'] ) ? sanitize_title( wp_unslash( $_GET['region'] ) ) : '';
-$region_term            = $region_slug ? get_term_by( 'slug', $region_slug, 'region' ) : null;
-$archive_columns        = 5;
-$archive_posts_per_page = 100;
+$region_slug = isset( $_GET['region'] ) ? sanitize_title( wp_unslash( $_GET['region'] ) ) : '';
+$region_term = $region_slug ? get_term_by( 'slug', $region_slug, 'region' ) : null;
 
 echo '<main class="wt_archive-territories">';
 
 if ( $region_term ) {
 	$region_name = wt_prefix_the( $region_term->name );
-	$params      = array(
-		'title'          => 'Territories of ' . $region_name,
-		'subtitle'       => '',
-		'show_total'     => 'true',
-		'post_type'      => 'territories',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => 'region',
-		'term'           => $region_term->slug,
-		'link_out'       => '',
+	$params      = wt_gallery_params(
+		array(
+			'title'         => 'Territories of ' . $region_name,
+			'post_type'     => 'territories',
+			'display_blank' => 'true',
+			'taxonomy'      => 'region',
+			'term'          => $region_term->slug,
+		)
 	);
 } else {
-	$params = array(
-		'title'          => 'Territories',
-		'subtitle'       => '',
-		'show_total'     => 'true',
-		'post_type'      => 'territories',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'     => 'Territories',
+			'post_type' => 'territories',
+		)
 	);
 }
 

--- a/wp-content/themes/blankslate-child/archive-videos.php
+++ b/wp-content/themes/blankslate-child/archive-videos.php
@@ -1,12 +1,12 @@
 <?php
 get_header();
 
-$language_slug          = isset( $_GET['language'] ) ? sanitize_title( wp_unslash( $_GET['language'] ) ) : '';
-$language_post          = $language_slug ? get_page_by_path( $language_slug, OBJECT, 'languages' ) : null;
-$archive_columns        = 5;
-$archive_posts_per_page = 100;
+$language_slug = isset( $_GET['language'] ) ? sanitize_title( wp_unslash( $_GET['language'] ) ) : '';
+$language_post = $language_slug ? get_page_by_path( $language_slug, OBJECT, 'languages' ) : null;
 
 echo '<main class="wt_archive-videos">';
+
+$subtitle = 'Wikitongues crowd-sources video samples of every language in the world.';
 
 if ( $language_post ) {
 	$standard_name = get_field( 'standard_name', $language_post->ID ) ?: $language_post->post_title;
@@ -15,44 +15,27 @@ if ( $language_post ) {
 		$title_name .= ' language';
 	}
 
-	$params = array(
-		'title'          => $title_name . ' videos',
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'videos',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'date',
-		'order'          => 'desc',
-		'pagination'     => 'true',
-		'meta_key'       => 'featured_languages',
-		'meta_value'     => $language_post->ID,
-		'selected_posts' => '',
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'         => $title_name . ' videos',
+			'subtitle'      => $subtitle,
+			'post_type'     => 'videos',
+			'orderby'       => 'date',
+			'order'         => 'desc',
+			'meta_key'      => 'featured_languages',
+			'meta_value'    => $language_post->ID,
+			'display_blank' => 'true',
+		)
 	);
 } else {
-	$params = array(
-		'title'          => 'Videos',
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'videos',
-		'columns'        => $archive_columns,
-		'posts_per_page' => $archive_posts_per_page,
-		'orderby'        => 'date',
-		'order'          => 'desc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'     => 'Videos',
+			'subtitle'  => $subtitle,
+			'post_type' => 'videos',
+			'orderby'   => 'date',
+			'order'     => 'desc',
+		)
 	);
 }
 

--- a/wp-content/themes/blankslate-child/includes/template/template-helpers.php
+++ b/wp-content/themes/blankslate-child/includes/template/template-helpers.php
@@ -83,8 +83,46 @@ function html5wp_pagination() {
  * is filled in automatically. Used by every create_gallery_instance() call
  * site across the theme.
  *
- * @param array $overrides Keys to override from the defaults.
- * @return array Full params array suitable for create_gallery_instance().
+ * @param array{
+ *   title?:          string,
+ *   subtitle?:       string,
+ *   show_total?:     string,
+ *   post_type?:      string,
+ *   custom_class?:   string,
+ *   columns?:        int,
+ *   posts_per_page?: int,
+ *   orderby?:        string,
+ *   order?:          string,
+ *   pagination?:     string,
+ *   meta_key?:       string,
+ *   meta_value?:     string|int,
+ *   selected_posts?: string,
+ *   display_blank?:  string,
+ *   exclude_self?:   string,
+ *   taxonomy?:       string,
+ *   term?:           string,
+ *   link_out?:       string,
+ * } $overrides Keys to override from the defaults.
+ * @return array{
+ *   title:          string,
+ *   subtitle:       string,
+ *   show_total:     string,
+ *   post_type:      string,
+ *   custom_class:   string,
+ *   columns:        int,
+ *   posts_per_page: int,
+ *   orderby:        string,
+ *   order:          string,
+ *   pagination:     string,
+ *   meta_key:       string,
+ *   meta_value:     string|int,
+ *   selected_posts: string,
+ *   display_blank:  string,
+ *   exclude_self:   string,
+ *   taxonomy:       string,
+ *   term:           string,
+ *   link_out:       string,
+ * } Full params array suitable for create_gallery_instance().
  */
 function wt_gallery_params( array $overrides ): array {
 	return array_merge(

--- a/wp-content/themes/blankslate-child/includes/template/template-helpers.php
+++ b/wp-content/themes/blankslate-child/includes/template/template-helpers.php
@@ -77,6 +77,42 @@ function html5wp_pagination() {
 }
 
 /**
+ * Build a gallery params array with sensible defaults.
+ *
+ * Callers pass only the keys that differ from the defaults; everything else
+ * is filled in automatically. Used by every create_gallery_instance() call
+ * site across the theme.
+ *
+ * @param array $overrides Keys to override from the defaults.
+ * @return array Full params array suitable for create_gallery_instance().
+ */
+function wt_gallery_params( array $overrides ): array {
+	return array_merge(
+		array(
+			'title'          => '',
+			'subtitle'       => '',
+			'show_total'     => 'true',
+			'post_type'      => '',
+			'custom_class'   => '',
+			'columns'        => 5,
+			'posts_per_page' => 100,
+			'orderby'        => 'title',
+			'order'          => 'asc',
+			'pagination'     => 'true',
+			'meta_key'       => '',
+			'meta_value'     => '',
+			'selected_posts' => '',
+			'display_blank'  => 'false',
+			'exclude_self'   => 'false',
+			'taxonomy'       => '',
+			'term'           => '',
+			'link_out'       => '',
+		),
+		$overrides
+	);
+}
+
+/**
  * Prefix a territory or region name with "The" where grammatically required.
  *
  * @param string $name Territory or region name.

--- a/wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
+++ b/wp-content/themes/blankslate-child/modules/flexible-content/gallery-layout.php
@@ -9,25 +9,19 @@ if ( have_rows( 'custom_gallery_posts' ) ) {
 		}
 
 		// Gallery
-		$params = array(
-			'title'          => get_sub_field( 'custom_gallery_title' ),
-			'subtitle'       => '',
-			'show_total'     => 'false',
-			'post_type'      => get_sub_field( 'custom_gallery_type' ),
-			'custom_class'   => 'full',
-			'columns'        => get_sub_field( 'custom_gallery_columns' ),
-			'posts_per_page' => get_sub_field( 'custom_gallery_posts_per_page' ),
-			'orderby'        => 'rand',
-			'order'          => 'asc',
-			'pagination'     => get_sub_field( 'custom_gallery_paginate' ),
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => esc_attr( $post_ids ),
-			'display_blank'  => 'false',
-			'exclude_self'   => 'true',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => get_sub_field( 'custom_gallery_title' ),
+				'post_type'      => get_sub_field( 'custom_gallery_type' ),
+				'custom_class'   => 'full',
+				'show_total'     => 'false',
+				'columns'        => get_sub_field( 'custom_gallery_columns' ),
+				'posts_per_page' => get_sub_field( 'custom_gallery_posts_per_page' ),
+				'orderby'        => 'rand',
+				'pagination'     => get_sub_field( 'custom_gallery_paginate' ),
+				'selected_posts' => esc_attr( $post_ids ),
+				'exclude_self'   => 'true',
+			)
 		);
 		echo create_gallery_instance( $params );
 	}

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__fellows.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__fellows.php
@@ -34,28 +34,23 @@ if ( $fellows ) :
 			$title_name .= ' language';
 		}
 			$title  = $title_name . ' Revitalization Projects';
-			$params = array(
-				'title'          => $title,
-				'subtitle'       => 'The Wikitongues Fellowship is an accelerator program where activists can learn from a network of revitalization projects.',
-				'show_total'     => 'false',
-				'post_type'      => 'fellows',
-				'custom_class'   => 'display',
-				'columns'        => 1,
-				'posts_per_page' => 1,
-				'orderby'        => 'date',
-				'order'          => 'asc',
-				'pagination'     => 'true',
-				'meta_key'       => 'fellow_language',
-				'meta_value'     => $language,
-				'selected_posts' => '',
-				'display_blank'  => 'false',
-				'exclude_self'   => 'true',
-				'taxonomy'       => '',
-				'term'           => '',
-				'link_out'       => '',
+			$params = wt_gallery_params(
+				array(
+					'title'          => $title,
+					'subtitle'       => 'The Wikitongues Fellowship is an accelerator program where activists can learn from a network of revitalization projects.',
+					'post_type'      => 'fellows',
+					'custom_class'   => 'display',
+					'show_total'     => 'false',
+					'columns'        => 1,
+					'posts_per_page' => 1,
+					'orderby'        => 'date',
+					'meta_key'       => 'fellow_language',
+					'meta_value'     => $language,
+					'exclude_self'   => 'true',
+				)
 			);
 			echo create_gallery_instance( $params );
-			?>
+		?>
 
 	</div>
 <?php endif; ?>

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__lexicons.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__lexicons.php
@@ -13,47 +13,35 @@ $title = $title_name . ' dictionaries, phrase books, and other lexicons';
 	</div>
 	<?php
 		// Gallery
-		$params = array(
-			'title'          => "{$standard_name} to other languages",
-			'subtitle'       => '',
-			'show_total'     => 'false',
-			'post_type'      => 'lexicons',
-			'custom_class'   => '',
-			'columns'        => 3,
-			'posts_per_page' => 6,
-			'orderby'        => 'date',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => 'source_languages',
-			'meta_value'     => $language,
-			'selected_posts' => '',
-			'display_blank'  => 'true',
-			'exclude_self'   => 'true',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => "{$standard_name} to other languages",
+				'post_type'      => 'lexicons',
+				'show_total'     => 'false',
+				'columns'        => 3,
+				'posts_per_page' => 6,
+				'orderby'        => 'date',
+				'meta_key'       => 'source_languages',
+				'meta_value'     => $language,
+				'display_blank'  => 'true',
+				'exclude_self'   => 'true',
+			)
 		);
 		echo create_gallery_instance( $params );
 
-		$params = array(
-			'title'          => "Other languages to {$standard_name}",
-			'subtitle'       => '',
-			'show_total'     => 'false',
-			'post_type'      => 'lexicons',
-			'custom_class'   => '',
-			'columns'        => 3,
-			'posts_per_page' => 6,
-			'orderby'        => 'date',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => 'target_languages',
-			'meta_value'     => $language,
-			'selected_posts' => '',
-			'display_blank'  => 'true',
-			'exclude_self'   => 'true',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => '',
+		$params = wt_gallery_params(
+			array(
+				'title'          => "Other languages to {$standard_name}",
+				'post_type'      => 'lexicons',
+				'show_total'     => 'false',
+				'columns'        => 3,
+				'posts_per_page' => 6,
+				'orderby'        => 'date',
+				'meta_key'       => 'target_languages',
+				'meta_value'     => $language,
+				'display_blank'  => 'true',
+				'exclude_self'   => 'true',
+			)
 		);
 		echo create_gallery_instance( $params );
 		?>

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__resources.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__resources.php
@@ -7,25 +7,20 @@
 			$title_name .= ' language';
 		}
 			$title  = $title_name . ' external resources';
-			$params = array(
-				'title'          => $title,
-				'subtitle'       => 'Wikitongues indexes language resources from across the internet.',
-				'show_total'     => 'false',
-				'post_type'      => 'resources',
-				'custom_class'   => '',
-				'columns'        => 3,
-				'posts_per_page' => 6,
-				'orderby'        => 'date',
-				'order'          => 'asc',
-				'pagination'     => 'true',
-				'meta_key'       => 'resource_language',
-				'meta_value'     => $language,
-				'selected_posts' => '',
-				'display_blank'  => 'true',
-				'exclude_self'   => 'true',
-				'taxonomy'       => '',
-				'term'           => '',
-				'link_out'       => '',
+			$params = wt_gallery_params(
+				array(
+					'title'          => $title,
+					'subtitle'       => 'Wikitongues indexes language resources from across the internet.',
+					'post_type'      => 'resources',
+					'show_total'     => 'false',
+					'columns'        => 3,
+					'posts_per_page' => 6,
+					'orderby'        => 'date',
+					'meta_key'       => 'resource_language',
+					'meta_value'     => $language,
+					'display_blank'  => 'true',
+					'exclude_self'   => 'true',
+				)
 			);
 			echo create_gallery_instance( $params );
 			?>

--- a/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
+++ b/wp-content/themes/blankslate-child/modules/languages/single-languages__videos.php
@@ -7,25 +7,20 @@
 		$title_name .= ' language';
 	}
 		$title  = $title_name . ' videos';
-		$params = array(
-			'title'          => $title,
-			'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-			'show_total'     => 'true',
-			'post_type'      => 'videos',
-			'custom_class'   => '',
-			'columns'        => 3,
-			'posts_per_page' => 6,
-			'orderby'        => 'date',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => 'featured_languages',
-			'meta_value'     => get_the_ID(),
-			'selected_posts' => '',
-			'display_blank'  => 'true',
-			'exclude_self'   => 'true',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => add_query_arg( 'language', get_post_field( 'post_name', get_the_ID() ), get_post_type_archive_link( 'videos' ) ),
+		$params = wt_gallery_params(
+			array(
+				'title'          => $title,
+				'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+				'post_type'      => 'videos',
+				'columns'        => 3,
+				'posts_per_page' => 6,
+				'orderby'        => 'date',
+				'meta_key'       => 'featured_languages',
+				'meta_value'     => get_the_ID(),
+				'display_blank'  => 'true',
+				'exclude_self'   => 'true',
+				'link_out'       => add_query_arg( 'language', get_post_field( 'post_name', get_the_ID() ), get_post_type_archive_link( 'videos' ) ),
+			)
 		);
 		echo create_gallery_instance( $params );
 		?>

--- a/wp-content/themes/blankslate-child/single-fellows.php
+++ b/wp-content/themes/blankslate-child/single-fellows.php
@@ -69,25 +69,20 @@ if ( $display_about && $fellowship_about ) {
 </div>
 <?php
 // Gallery
-$params = array(
-	'title'          => '',
-	'subtitle'       => '',
-	'show_total'     => 'false',
-	'post_type'      => 'fellows',
-	'custom_class'   => 'full',
-	'columns'        => 4,
-	'posts_per_page' => 4,
-	'orderby'        => 'rand',
-	'order'          => '',
-	'pagination'     => 'false',
-	'meta_key'       => 'fellow_year',
-	'meta_value'     => $fellow_year,
-	'selected_posts' => '',
-	'display_blank'  => 'false',
-	'exclude_self'   => 'true',
-	'taxonomy'       => '',
-	'term'           => '',
-	'link_out'       => '',
+$params = wt_gallery_params(
+	array(
+		'post_type'      => 'fellows',
+		'custom_class'   => 'full',
+		'show_total'     => 'false',
+		'columns'        => 4,
+		'posts_per_page' => 4,
+		'orderby'        => 'rand',
+		'order'          => '',
+		'pagination'     => 'false',
+		'meta_key'       => 'fellow_year',
+		'meta_value'     => $fellow_year,
+		'exclude_self'   => 'true',
+	)
 );
 echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/single-languages.php
+++ b/wp-content/themes/blankslate-child/single-languages.php
@@ -66,25 +66,17 @@ if ( $territories ) {
 		? add_query_arg( 'territory', $territories[0]->post_name, get_post_type_archive_link( 'languages' ) )
 		: '';
 
-	$params = array(
-		'title'          => $gallery_title,
-		'subtitle'       => '',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'custom_class'   => 'full',
-		'columns'        => 5,
-		'posts_per_page' => 5,
-		'orderby'        => 'rand',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => $selected,
-		'display_blank'  => 'false',
-		'exclude_self'   => 'true',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => $gallery_link_out,
+	$params = wt_gallery_params(
+		array(
+			'title'          => $gallery_title,
+			'post_type'      => 'languages',
+			'custom_class'   => 'full',
+			'posts_per_page' => 5,
+			'orderby'        => 'rand',
+			'selected_posts' => $selected,
+			'exclude_self'   => 'true',
+			'link_out'       => $gallery_link_out,
+		)
 	);
 	echo create_gallery_instance( $params );
 }

--- a/wp-content/themes/blankslate-child/single-territories.php
+++ b/wp-content/themes/blankslate-child/single-territories.php
@@ -29,25 +29,15 @@
 	if ( $fellows_query->have_posts() ) {
 		$fellow_ids = wp_list_pluck( $fellows_query->posts, 'ID' );
 		wp_reset_postdata();
-		$fellows_params = array(
-			'title'          => 'Fellows from ' . $territory,
-			'subtitle'       => '',
-			'show_total'     => 'true',
-			'post_type'      => 'fellows',
-			'custom_class'   => '',
-			'columns'        => 3,
-			'posts_per_page' => 3,
-			'orderby'        => 'title',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => implode( ',', $fellow_ids ),
-			'display_blank'  => 'false',
-			'exclude_self'   => 'false',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'fellows' ) ),
+		$fellows_params = wt_gallery_params(
+			array(
+				'title'          => 'Fellows from ' . $territory,
+				'post_type'      => 'fellows',
+				'columns'        => 3,
+				'posts_per_page' => 3,
+				'selected_posts' => implode( ',', $fellow_ids ),
+				'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'fellows' ) ),
+			)
 		);
 		echo create_gallery_instance( $fellows_params );
 	}
@@ -57,25 +47,18 @@
 	// Territories like India (403 languages) would otherwise time out.
 	$languages    = get_field( 'languages', get_the_ID(), false );
 	$language_ids = $languages ? implode( ',', $languages ) : '';
-	$params       = array(
-		'title'          => 'Languages of ' . $territory,
-		'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
-		'show_total'     => 'true',
-		'post_type'      => 'languages',
-		'custom_class'   => '',
-		'columns'        => 3,
-		'posts_per_page' => 6,
-		'orderby'        => $language_ids,
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => $language_ids,
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'languages' ) ),
+	$params       = wt_gallery_params(
+		array(
+			'title'          => 'Languages of ' . $territory,
+			'subtitle'       => 'Wikitongues crowd-sources video samples of every language in the world.',
+			'post_type'      => 'languages',
+			'columns'        => 3,
+			'posts_per_page' => 6,
+			'orderby'        => $language_ids,
+			'selected_posts' => $language_ids,
+			'display_blank'  => 'true',
+			'link_out'       => add_query_arg( 'territory', $territory_slug, get_post_type_archive_link( 'languages' ) ),
+		)
 	);
 	echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/single-videos.php
+++ b/wp-content/themes/blankslate-child/single-videos.php
@@ -71,25 +71,19 @@ echo '<main class="wt_single-videos__content">';
 	echo '</section>';
 
 	// Gallery
-	$params = array(
-		'title'          => 'Other videos of ' . $language_names,
-		'subtitle'       => '',
-		'show_total'     => 'false',
-		'post_type'      => 'videos',
-		'custom_class'   => 'full',
-		'columns'        => 5,
-		'posts_per_page' => 5,
-		'orderby'        => 'rand',
-		'order'          => 'asc',
-		'pagination'     => 'false',
-		'meta_key'       => 'featured_languages',
-		'meta_value'     => $language_ids_string,
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'true',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'          => 'Other videos of ' . $language_names,
+			'post_type'      => 'videos',
+			'custom_class'   => 'full',
+			'show_total'     => 'false',
+			'posts_per_page' => 5,
+			'orderby'        => 'rand',
+			'pagination'     => 'false',
+			'meta_key'       => 'featured_languages',
+			'meta_value'     => $language_ids_string,
+			'exclude_self'   => 'true',
+		)
 	);
 	echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/taxonomy-fellow-category.php
+++ b/wp-content/themes/blankslate-child/taxonomy-fellow-category.php
@@ -40,25 +40,19 @@
 <div class="archive-content">
 
 	<?php
-	$params = array(
-		'title'          => '',
-		'subtitle'       => '',
-		'show_total'     => 'false',
-		'post_type'      => 'fellows',
-		'custom_class'   => 'full',
-		'columns'        => 4,
-		'posts_per_page' => '50',
-		'orderby'        => 'year',
-		'order'          => 'desc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => '',
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => 'fellow-category',
-		'term'           => $category->slug,
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'post_type'      => 'fellows',
+			'custom_class'   => 'full',
+			'show_total'     => 'false',
+			'columns'        => 4,
+			'posts_per_page' => 50,
+			'orderby'        => 'year',
+			'order'          => 'desc',
+			'display_blank'  => 'true',
+			'taxonomy'       => 'fellow-category',
+			'term'           => $category->slug,
+		)
 	);
 		echo create_gallery_instance( $params );
 	?>

--- a/wp-content/themes/blankslate-child/taxonomy-region.php
+++ b/wp-content/themes/blankslate-child/taxonomy-region.php
@@ -75,25 +75,15 @@ if ( $territory_query->have_posts() ) :
 	if ( $fellows_query->have_posts() ) {
 		$fellow_ids = wp_list_pluck( $fellows_query->posts, 'ID' );
 		wp_reset_postdata();
-		$fellows_params = array(
-			'title'          => 'Fellows from ' . $territory,
-			'subtitle'       => '',
-			'show_total'     => 'true',
-			'post_type'      => 'fellows',
-			'custom_class'   => '',
-			'columns'        => 3,
-			'posts_per_page' => 3,
-			'orderby'        => 'title',
-			'order'          => 'asc',
-			'pagination'     => 'true',
-			'meta_key'       => '',
-			'meta_value'     => '',
-			'selected_posts' => implode( ',', $fellow_ids ),
-			'display_blank'  => 'false',
-			'exclude_self'   => 'false',
-			'taxonomy'       => '',
-			'term'           => '',
-			'link_out'       => add_query_arg( 'region', $region_slug, get_post_type_archive_link( 'fellows' ) ),
+		$fellows_params = wt_gallery_params(
+			array(
+				'title'          => 'Fellows from ' . $territory,
+				'post_type'      => 'fellows',
+				'columns'        => 3,
+				'posts_per_page' => 3,
+				'selected_posts' => implode( ',', $fellow_ids ),
+				'link_out'       => add_query_arg( 'region', $region_slug, get_post_type_archive_link( 'fellows' ) ),
+			)
 		);
 		echo create_gallery_instance( $fellows_params );
 	}
@@ -110,25 +100,18 @@ if ( $territory_query->have_posts() ) :
 		$gallery_term     = '';
 	}
 
-	$params = array(
-		'title'          => 'Territories in ' . $territory,
-		'subtitle'       => '',
-		'show_total'     => 'true',
-		'post_type'      => 'territories',
-		'custom_class'   => '',
-		'columns'        => 3,
-		'posts_per_page' => 9,
-		'orderby'        => 'title',
-		'order'          => 'asc',
-		'pagination'     => 'true',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => $selected_posts,
-		'display_blank'  => 'true',
-		'exclude_self'   => 'false',
-		'taxonomy'       => $gallery_taxonomy,
-		'term'           => $gallery_term,
-		'link_out'       => add_query_arg( 'region', $region_slug, get_post_type_archive_link( 'territories' ) ),
+	$params = wt_gallery_params(
+		array(
+			'title'          => 'Territories in ' . $territory,
+			'post_type'      => 'territories',
+			'columns'        => 3,
+			'posts_per_page' => 9,
+			'selected_posts' => $selected_posts,
+			'display_blank'  => 'true',
+			'taxonomy'       => $gallery_taxonomy,
+			'term'           => $gallery_term,
+			'link_out'       => add_query_arg( 'region', $region_slug, get_post_type_archive_link( 'territories' ) ),
+		)
 	);
 	echo create_gallery_instance( $params );
 

--- a/wp-content/themes/blankslate-child/template-about-staff.php
+++ b/wp-content/themes/blankslate-child/template-about-staff.php
@@ -32,23 +32,18 @@ foreach ( $staff_members as $post ) {
 } wp_reset_postdata();
 echo '</div>';
 // Gallery
-$careers = array(
-	'title'          => 'Explore careers',
-	'post_type'      => 'careers',
-	'custom_class'   => '',
-	'columns'        => 1,
-	'posts_per_page' => 3,
-	'orderby'        => 'rand',
-	'order'          => 'asc',
-	'pagination'     => 'false',
-	'meta_key'       => '',
-	'meta_value'     => '',
-	'selected_posts' => '',
-	'display_blank'  => 'false',
-	'exclude_self'   => 'true',
-	'taxonomy'       => 'career_type',
-	'term'           => 'Staff',
-	'link_out'       => '',
+$careers = wt_gallery_params(
+	array(
+		'title'          => 'Explore careers',
+		'post_type'      => 'careers',
+		'columns'        => 1,
+		'posts_per_page' => 3,
+		'orderby'        => 'rand',
+		'pagination'     => 'false',
+		'exclude_self'   => 'true',
+		'taxonomy'       => 'career_type',
+		'term'           => 'Staff',
+	)
 );
 echo create_gallery_instance( $careers );
 
@@ -69,23 +64,19 @@ if ( $interns_and_volunteers ) {
 }
 echo '</div>';
 // Gallery
-$otherOpportunities = array(
-	'title'          => 'Explore other opportunities',
-	'post_type'      => 'careers',
-	'custom_class'   => '',
-	'columns'        => 1,
-	'posts_per_page' => 3,
-	'orderby'        => 'rand',
-	'order'          => 'asc',
-	'pagination'     => 'false',
-	'meta_key'       => '',
-	'meta_value'     => '',
-	'selected_posts' => '',
-	'display_blank'  => 'false',
-	'exclude_self'   => 'true',
-	'taxonomy'       => 'career_type',
-	'term'           => 'Intern,Volunteer',
-	'link_out'       => '',
+$otherOpportunities = wt_gallery_params(
+	array(
+		'title'          => 'Explore other opportunities',
+		'post_type'      => 'careers',
+		'columns'        => 1,
+		'posts_per_page' => 3,
+		'orderby'        => 'rand',
+		'pagination'     => 'false',
+		'show_total'     => 'false',
+		'exclude_self'   => 'true',
+		'taxonomy'       => 'career_type',
+		'term'           => 'Intern,Volunteer',
+	)
 );
 echo create_gallery_instance( $otherOpportunities );
 

--- a/wp-content/themes/blankslate-child/template-about-staff.php
+++ b/wp-content/themes/blankslate-child/template-about-staff.php
@@ -40,6 +40,7 @@ $careers = wt_gallery_params(
 		'posts_per_page' => 3,
 		'orderby'        => 'rand',
 		'pagination'     => 'false',
+		'show_total'     => 'false',
 		'exclude_self'   => 'true',
 		'taxonomy'       => 'career_type',
 		'term'           => 'Staff',

--- a/wp-content/themes/blankslate-child/template-giving-campaign-24.php
+++ b/wp-content/themes/blankslate-child/template-giving-campaign-24.php
@@ -47,25 +47,19 @@ require 'modules/banners/banner--main.php';
 		$post_ids = implode( ',', wp_list_pluck( $custom_posts['custom_gallery_posts'], 'ID' ) );
 	}
 	// Gallery
-	$params = array(
-		'title'          => get_sub_field( 'custom_gallery_title' ),
-		'subtitle'       => '',
-		'show_total'     => 'false',
-		'post_type'      => 'fellows',
-		'custom_class'   => 'custom fundraiser',
-		'columns'        => 1,
-		'posts_per_page' => 5,
-		'orderby'        => 'rand',
-		'order'          => 'asc',
-		'pagination'     => 'false',
-		'meta_key'       => '',
-		'meta_value'     => '',
-		'selected_posts' => esc_attr( $post_ids ),
-		'display_blank'  => 'false',
-		'exclude_self'   => 'true',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'title'          => get_sub_field( 'custom_gallery_title' ),
+			'post_type'      => 'fellows',
+			'custom_class'   => 'custom fundraiser',
+			'show_total'     => 'false',
+			'columns'        => 1,
+			'posts_per_page' => 5,
+			'orderby'        => 'rand',
+			'pagination'     => 'false',
+			'selected_posts' => esc_attr( $post_ids ),
+			'exclude_self'   => 'true',
+		)
 	);
 	echo create_gallery_instance( $params );
 	?>

--- a/wp-content/themes/blankslate-child/template-revitalization-fellows.php
+++ b/wp-content/themes/blankslate-child/template-revitalization-fellows.php
@@ -55,25 +55,19 @@ if ( $fellow_id ) {
 
 <?php
 	// Gallery
-	$params = array(
-		'title'          => '',
-		'subtitle'       => '',
-		'show_total'     => 'false',
-		'post_type'      => 'fellows',
-		'custom_class'   => 'full',
-		'columns'        => 4,
-		'posts_per_page' => 60,
-		'orderby'        => 'rand',
-		'order'          => '',
-		'pagination'     => 'true',
-		'meta_key'       => 'fellow_year',
-		'meta_value'     => isset( $_GET['fellow_year'] ) ? sanitize_text_field( $_GET['fellow_year'] ) : $cohorts[0],
-		'selected_posts' => '',
-		'display_blank'  => 'false',
-		'exclude_self'   => 'true',
-		'taxonomy'       => '',
-		'term'           => '',
-		'link_out'       => '',
+	$params = wt_gallery_params(
+		array(
+			'post_type'      => 'fellows',
+			'custom_class'   => 'full',
+			'show_total'     => 'false',
+			'columns'        => 4,
+			'posts_per_page' => 60,
+			'orderby'        => 'rand',
+			'order'          => '',
+			'meta_key'       => 'fellow_year',
+			'meta_value'     => isset( $_GET['fellow_year'] ) ? sanitize_text_field( $_GET['fellow_year'] ) : $cohorts[0],
+			'exclude_self'   => 'true',
+		)
 	);
 	echo create_gallery_instance( $params );
 


### PR DESCRIPTION
## Summary

- Adds \`wt_gallery_params( array \$overrides ): array\` to \`template-helpers.php\` — merges caller-provided keys with a full set of defaults, so callers only specify what differs
- Renames \`wt_archive_params()\` → \`wt_gallery_params()\` and adds \`custom_class\` to defaults
- Expands usage from 4 archive files to all 26 \`create_gallery_instance()\` call sites across 18 files — eliminates repetitive 17–19 key boilerplate arrays throughout the theme
- Adds full \`@param\`/\`@return\` PHPDoc array shape annotations — PHPStan enforces valid keys and types; Intelephense shows hover docs for all 18 params
- Fixes \`posts_per_page: '50'\` (string) → \`50\` (int) in \`taxonomy-fellow-category.php\`
- Fixes \`show_total\` missing/incorrect in \`template-about-staff.php\`
- Adds \`docs/gallery-inventory.csv\` + \`docs/gallery-inventory-main.csv\` inventorying every gallery's effective settings before and after
- Adds \`.vscode/extensions.json\` recommending PHP Intelephense for contributors

## Test plan

This is a pure refactor — no gallery behaviour should change. Verify each surface renders identically to main.

### Archive pages
- [ ] \`/fellows\` — base list renders
- [ ] \`/fellows?territory=<slug>\` — filtered by territory (with and without linked fellows)
- [ ] \`/fellows?region=<slug>\` — filtered by region (try a sub-region and a continent)
- [ ] \`/languages\` — base list renders
- [ ] \`/languages?territory=<slug>\` — filtered by territory
- [ ] \`/languages?genealogy=<slug>\` — filtered by linguistic family
- [ ] \`/languages?writing_system=<slug>\` — filtered by writing system
- [ ] \`/videos\` — base list renders
- [ ] \`/videos?language=<slug>\` — filtered by language
- [ ] \`/territories\` — base list renders
- [ ] \`/territories?region=<slug>\` — filtered by region

### Single pages
- [ ] Single territory — fellows gallery (if linked) and languages gallery both render
- [ ] Single language — videos, fellows/revitalization, lexicons (source + target), and resources galleries all render
- [ ] Single video — related videos gallery renders
- [ ] Single fellow — cohort gallery renders

### Taxonomy pages
- [ ] \`/region/<slug>\` — sub-region: fellows + territories galleries render
- [ ] \`/region/<continent-slug>\` — continent: fellows + territories galleries render (expanded to child terms)
- [ ] \`/fellow-category/<slug>\` — fellows gallery renders

### Page templates
- [ ] Revitalization Fellows — cohort gallery renders; switching year via nav updates gallery
- [ ] Staff — careers and volunteer opportunities galleries both render
- [ ] Giving Campaign 24 — case studies gallery renders

### Flexible content
- [ ] Any page using the gallery flexible content block renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)