### PR TITLE
Make include_children explicit in gallery tax_query (Phase 3 item 7)

### DIFF
--- a/docs/plan-archive.md
+++ b/docs/plan-archive.md
@@ -5,6 +5,40 @@ Each entry includes branch, PR, merge commit, and a summary of what was done.
 
 ---
 
+## 2026-03-06 (Phase 3 item 6)
+
+### Phase 3 item 6 — Archive template refactor + `wt_gallery_params()` helper
+**Branch:** `refactor/cc/archive-template-helper`
+**PR:** [#536](https://github.com/wikitongues/wikitongues.org/pull/536)
+
+- Added `wt_gallery_params( array $overrides ): array` to `template-helpers.php` — merges caller-provided keys with a full set of defaults so callers only specify what differs
+- Renamed `wt_archive_params()` → `wt_gallery_params()` and added `custom_class` to defaults
+- Expanded usage from 4 archive files to all 26 `create_gallery_instance()` call sites across 18 files — eliminates 17–19 key boilerplate arrays throughout the theme
+- Added full `@param`/`@return` PHPDoc array shape annotations — PHPStan enforces valid keys and types; Intelephense provides hover docs for all 18 params
+- Fixed `posts_per_page: '50'` (string) → `50` (int) in `taxonomy-fellow-category.php`
+- Fixed `show_total` missing/incorrect in `template-about-staff.php`
+- Added `docs/gallery-inventory.csv` + `docs/gallery-inventory-main.csv` inventorying every gallery's effective settings before and after
+- Added `.vscode/extensions.json` recommending PHP Intelephense for contributors
+
+---
+
+## 2026-03-06 (Phase 3 item 7)
+
+### Phase 3 item 7 — `gallery-territories.php` + `archive-territories.php` fixes
+**Branch:** `fix/cc/territories-gallery-fixes`
+**PR:** [#538](https://github.com/wikitongues/wikitongues.org/pull/538)
+
+All four `gallery-territories.php` bugs were already fixed in the plugin prior to this PR:
+- Double query (no_found_rows) — already removed; `found_posts` read from single query
+- XSS in alt attribute — already uses `esc_attr( get_the_title() )`
+- Blank label — already uses `get_field('standard_name', ...) ?: get_the_title()`
+- Filter bypass — already uses `get_the_title()` for video lookup
+
+Remaining fix applied in this PR:
+- Added explicit `'include_children' => true` to the `tax_query` built in `build_gallery_query_args()` (`wt-gallery/includes/queries.php`) — WP already defaults to `true` but making it explicit prevents a silent regression if the query builder is ever changed
+
+---
+
 ## 2026-03-05 (Phase 3 items 4–5)
 
 ### Phase 3 item 4 — Reorganize theme `includes/` into subdirectories + autoloader

--- a/plan.md
+++ b/plan.md
@@ -96,22 +96,13 @@ See [archive](docs/plan-archive.md) (PR #529).
 
 See [archive](docs/plan-archive.md) (PR #529).
 
-#### 6. Archive template refactor _(before Docker)_
+#### ~~6. Archive template refactor~~ ✅
 
-`archive-languages.php`, `archive-fellows.php`, `archive-videos.php` share a structural pattern with boilerplate repeated across files. Evaluate a shared archive helper or declarative config approach. `archive-donors.php` intentionally does NOT use `create_gallery_instance()` — out of scope.
+See [archive](docs/plan-archive.md) (PR #536).
 
-**PHPDoc array shapes** — `wt_gallery_params()` now carries full `@param`/`@return` array shape annotations (PHPStan + IDE autocomplete). Evaluate applying this pattern consistently to other helper functions across the project: `wt_social_links()`, `wt_archive_params()` callers, any function accepting or returning a structured array. Goal: callers should never need to open a function definition to know its contract.
+#### ~~7. `gallery-territories.php` + `archive-territories.php` fixes~~ ✅
 
-#### 7. `gallery-territories.php` + `archive-territories.php` fixes _(combines former F + G)_
-
-**`gallery-territories.php`:**
-- **Double query** — drop `no_found_rows=true` from the preview query and read `found_posts` directly; halves query count per card (55 cards × 1 saved query = 55 fewer SQL calls on the Asia archive page)
-- **XSS** — `get_the_title()` in the `alt` attribute not escaped; should be `esc_attr( get_the_title() )`
-- **Blank label** — `get_field('standard_name', ...)` returns null when unset; no fallback to `post_title`
-- **Filter bypass** — `$language_post->post_title` used for video lookup instead of `get_the_title()`
-
-**`archive-territories.php`:**
-- `?region=<continent-slug>` filter relies on WP defaulting `tax_query` to `include_children => true`. Add explicit `include_children => true` or a comment — if `build_gallery_query_args()` ever adds an explicit `false`, continent archive pages silently break.
+See [archive](docs/plan-archive.md) (PR #538).
 
 
 #### 8. Fellows ACF field audit _(parallel)_

--- a/wp-content/plugins/wt-gallery/includes/queries.php
+++ b/wp-content/plugins/wt-gallery/includes/queries.php
@@ -76,9 +76,10 @@ function build_gallery_query_args( $atts = array() ) {
 	} elseif ( ! empty( $atts['taxonomy'] ) && ! empty( $atts['term'] ) ) {
 		$args['tax_query'] = array(
 			array(
-				'taxonomy' => $atts['taxonomy'],
-				'field'    => 'slug',
-				'terms'    => $atts['term'],
+				'taxonomy'         => $atts['taxonomy'],
+				'field'            => 'slug',
+				'terms'            => $atts['term'],
+				'include_children' => true, // explicit: continent slugs must include child regions
 			),
 		);
 	}


### PR DESCRIPTION
## Summary
- Adds explicit `'include_children' => true` to the `tax_query` built in `build_gallery_query_args()` in `wt-gallery/includes/queries.php`
- WP already defaults to `true`, so this is a no-op at runtime — but making it explicit prevents a silent regression if the query builder is ever changed
- The four `gallery-territories.php` bugs listed in the plan (double query, XSS, blank label, filter bypass) were already fixed in the plugin; this PR documents that and closes out item 7

## Test plan
- [ ] `/territories` — base list renders correctly
- [ ] `/territories?region=<continent-slug>` — territories from all child regions are included (e.g. Asia shows territories across all Asian sub-regions)
- [ ] `/territories?region=<sub-region-slug>` — filtered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)