### PR TITLE
Download Gateway sub-phases 0–5

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,6 +16,21 @@ parameters:
 			path: tests/unit/download-gateway/TokenRepositoryTest.php
 
 		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:once\\(\\)\\.$#"
+			count: 13
+			path: tests/unit/download-gateway/PeopleRepositoryTest.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:once\\(\\)\\.$#"
+			count: 5
+			path: tests/unit/download-gateway/GateControllerTest.php
+
+		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:twice\\(\\)\\.$#"
+			count: 1
+			path: tests/unit/download-gateway/GateControllerTest.php
+
+		-
 			message: "#^Function get_field not found\\.$#"
 			count: 1
 			path: wp-content/plugins/download-gateway/includes/class-document-file-resolver.php

--- a/plan.md
+++ b/plan.md
@@ -229,11 +229,11 @@ Downloads currently go through unprotected direct file URLs or `force_download_f
 - [x] **0** — Plugin scaffold: activation/deactivation/uninstall hooks, `GATEWAY_ENABLED` feature flag, settings page placeholder, Logger (PR #560)
 - [x] **1** — Data model: 4 tables created via `dbDelta()` on activation; idempotent (PR #560)
 - [x] **2a** — Core primitives: `PolicyResolver` (per-resource → taxonomy → global), `SettingsRepository`, `EventBus` (namespaced WP hooks), `DownloadEventRepository` (PR #560)
-- **2b** — Form/gate primitives _(unblocks 5)_: FormSchemaRegistry, Validator, SubmissionService, PeopleRepository, RateLimiter + honeypot, modal UI kit
+- [x] **2b** — Collapsed into sub-phase 5: PeopleRepository, GateController, rate limiter (transients), honeypot, modal UI
 - **2c** — Deferrable primitives: WebhookDispatcher (retry + dead-letter), RetentionJob skeleton + cron registration
 - [x] **3** — Download endpoint: `GET /wp-json/gateway/v1/download/{token-or-post-id}`, `gateway_vid` visitor cookie, click + redirect event logging, IP hashing, no-cache headers. Tested on localhost — 302 redirect confirmed (PR #560)
 - [x] **4** — Resource authoring: ACF gate policy override field (per-resource, via `acf_add_local_field_group()`), metabox showing gateway URL + shortcode snippet, `[gateway_download]` shortcode. All three validated on localhost.
-- **5** — Gate modes: soft gate (skippable) and hard gate (email required); `POST /wp-json/gateway/v1/gate`; person upsert; one-time token; nonce + rate limit + honeypot
+- [x] **5** — Gate modes: soft (skippable modal) and hard (email required); `POST /wp-json/gateway/v1/gate`; PeopleRepository upsert; one-time token; nonce + rate limit + honeypot. All policy permutations validated on localhost.
 
 **Implementation notes:**
 - WP Cron fires on page visits only — production retention job should be backed by server cron (`wp cron event run --due-now`)

--- a/plan.md
+++ b/plan.md
@@ -232,7 +232,7 @@ Downloads currently go through unprotected direct file URLs or `force_download_f
 - **2b** — Form/gate primitives _(unblocks 5)_: FormSchemaRegistry, Validator, SubmissionService, PeopleRepository, RateLimiter + honeypot, modal UI kit
 - **2c** — Deferrable primitives: WebhookDispatcher (retry + dead-letter), RetentionJob skeleton + cron registration
 - [x] **3** — Download endpoint: `GET /wp-json/gateway/v1/download/{token-or-post-id}`, `gateway_vid` visitor cookie, click + redirect event logging, IP hashing, no-cache headers. Tested on localhost — 302 redirect confirmed (PR #560)
-- **4** — Resource authoring: ACF fields on `document_files` and other CPTs (gate_policy override, storage_type); metabox showing gateway URL; `[gateway_download]` shortcode
+- [x] **4** — Resource authoring: ACF gate policy override field (per-resource, via `acf_add_local_field_group()`), metabox showing gateway URL + shortcode snippet, `[gateway_download]` shortcode. All three validated on localhost.
 - **5** — Gate modes: soft gate (skippable) and hard gate (email required); `POST /wp-json/gateway/v1/gate`; person upsert; one-time token; nonce + rate limit + honeypot
 
 **Implementation notes:**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,8 @@ require_once GATEWAY_DIR . 'includes/class-policy-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-event-bus.php';
 require_once GATEWAY_DIR . 'includes/class-download-event-repository.php';
 require_once GATEWAY_DIR . 'includes/class-download-controller.php';
+require_once GATEWAY_DIR . 'includes/class-people-repository.php';
+require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
 
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/integrations/acf-helpers.php';
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/template/search-filter.php';

--- a/tests/unit/download-gateway/GateControllerTest.php
+++ b/tests/unit/download-gateway/GateControllerTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use WT\DownloadGateway\GateController;
+use WT\DownloadGateway\PeopleRepository;
+
+class GateControllerTest extends TestCase {
+
+	private GateController $controller;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->controller = new GateController();
+
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_email', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_key', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'esc_url_raw', array( 'return_arg' => 0 ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Spam / abuse prevention
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_silent_success_when_honeypot_filled(): void {
+		$result = $this->controller->submit( 42, 'user@example.com', 'Jane', true, 'nonce', 'bot-value' );
+		$this->assertIsArray( $result );
+		$this->assertNull( $result['token'] );
+	}
+
+	public function test_submit_returns_403_for_invalid_nonce(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => false ) );
+
+		$result = $this->controller->submit( 42, 'user@example.com', 'Jane', true, 'bad-nonce', '' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	public function test_submit_returns_429_when_rate_limit_exceeded(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 10 ) ); // at limit
+
+		$result = $this->controller->submit( 42, 'user@example.com', 'Jane', true, 'valid-nonce', '', array(), array( 'REMOTE_ADDR' => '10.0.0.1' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 429, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Field validation
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_400_for_invalid_post_id(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 0 ) );
+		WP_Mock::userFunction( 'set_transient', array( 'return' => true ) );
+
+		$result = $this->controller->submit( 0, 'user@example.com', 'Jane', true, 'valid-nonce', '', array(), array( 'REMOTE_ADDR' => '10.0.0.1' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_submit_returns_400_for_invalid_email(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 0 ) );
+		WP_Mock::userFunction( 'set_transient', array( 'return' => true ) );
+		WP_Mock::userFunction( 'is_email', array( 'return' => false ) );
+
+		$result = $this->controller->submit( 42, 'not-an-email', 'Jane', true, 'valid-nonce', '', array(), array( 'REMOTE_ADDR' => '10.0.0.1' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( 'invalid_email', $result->get_error_code() );
+	}
+
+	public function test_submit_returns_400_for_empty_name(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 0 ) );
+		WP_Mock::userFunction( 'set_transient', array( 'return' => true ) );
+		WP_Mock::userFunction( 'is_email', array( 'return' => true ) );
+
+		$result = $this->controller->submit( 42, 'user@example.com', '   ', true, 'valid-nonce', '', array(), array( 'REMOTE_ADDR' => '10.0.0.1' ) );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( 'invalid_name', $result->get_error_code() );
+	}
+
+	// -------------------------------------------------------------------------
+	// Happy path
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_token_on_success(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 1;
+		$wpdb->last_error = '';
+		// people upsert: prepare (SELECT) + get_var (null = new) + insert
+		// token create: insert
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$wpdb->shouldReceive( 'insert' )->twice()->andReturn( 1 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 0 ) );
+		WP_Mock::userFunction( 'set_transient', array( 'return' => true ) );
+		WP_Mock::userFunction( 'is_email', array( 'return' => true ) );
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-15 10:00:00' ) );
+
+		$result = $this->controller->submit(
+			42,
+			'user@example.com',
+			'Jane Doe',
+			true,
+			'valid-nonce',
+			'',
+			array(),
+			array( 'REMOTE_ADDR' => '10.0.0.1' )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'token', $result );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{64}$/', $result['token'] );
+	}
+
+	public function test_submit_returns_500_on_db_error(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$wpdb->shouldReceive( 'insert' )->once()->andReturn( false ); // people insert fails
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_transient', array( 'return' => 0 ) );
+		WP_Mock::userFunction( 'set_transient', array( 'return' => true ) );
+		WP_Mock::userFunction( 'is_email', array( 'return' => true ) );
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-15 10:00:00' ) );
+
+		$result = $this->controller->submit(
+			42,
+			'user@example.com',
+			'Jane Doe',
+			true,
+			'valid-nonce',
+			'',
+			array(),
+			array( 'REMOTE_ADDR' => '10.0.0.1' )
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/unit/download-gateway/PeopleRepositoryTest.php
+++ b/tests/unit/download-gateway/PeopleRepositoryTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use WT\DownloadGateway\PeopleRepository;
+
+class PeopleRepositoryTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// hash_email() — pure function, no mocking required
+	// -------------------------------------------------------------------------
+
+	public function test_hash_email_returns_64_char_hex(): void {
+		$hash = PeopleRepository::hash_email( 'user@example.com' );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{64}$/', $hash );
+	}
+
+	public function test_hash_email_is_case_insensitive(): void {
+		$this->assertSame(
+			PeopleRepository::hash_email( 'User@Example.COM' ),
+			PeopleRepository::hash_email( 'user@example.com' )
+		);
+	}
+
+	public function test_hash_email_trims_whitespace(): void {
+		$this->assertSame(
+			PeopleRepository::hash_email( '  user@example.com  ' ),
+			PeopleRepository::hash_email( 'user@example.com' )
+		);
+	}
+
+	public function test_different_emails_produce_different_hashes(): void {
+		$this->assertNotSame(
+			PeopleRepository::hash_email( 'a@example.com' ),
+			PeopleRepository::hash_email( 'b@example.com' )
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// upsert() — insert path
+	// -------------------------------------------------------------------------
+
+	public function test_upsert_inserts_new_person_and_returns_id(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb             = Mockery::mock( 'wpdb' );
+		$wpdb->prefix     = 'wp_';
+		$wpdb->insert_id  = 7;
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-15 10:00:00' ) );
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_email', array( 'return_arg' => 0 ) );
+
+		$result = PeopleRepository::upsert( 'user@example.com', 'Jane Doe', true );
+
+		$this->assertSame( 7, $result );
+	}
+
+	public function test_upsert_returns_false_on_db_error(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
+		$wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-15 10:00:00' ) );
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_email', array( 'return_arg' => 0 ) );
+
+		$result = PeopleRepository::upsert( 'user@example.com', 'Jane Doe', true );
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// upsert() — update path
+	// -------------------------------------------------------------------------
+
+	public function test_upsert_updates_existing_person_and_returns_existing_id(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( '42' );
+		$wpdb->shouldReceive( 'update' )->once()->andReturn( 1 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+
+		$result = PeopleRepository::upsert( 'user@example.com', 'Jane Doe', true );
+
+		$this->assertSame( 42, $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// find_by_email()
+	// -------------------------------------------------------------------------
+
+	public function test_find_by_email_returns_row_when_found(): void {
+		$row             = new stdClass();
+		$row->id         = 5;
+		$row->email_hash = PeopleRepository::hash_email( 'user@example.com' );
+
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_row' )->once()->andReturn( $row );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$result = PeopleRepository::find_by_email( 'user@example.com' );
+
+		$this->assertSame( $row, $result );
+	}
+
+	public function test_find_by_email_returns_null_when_not_found(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
+		$wpdb->shouldReceive( 'get_row' )->once()->andReturn( null );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		$result = PeopleRepository::find_by_email( 'nobody@example.com' );
+
+		$this->assertNull( $result );
+	}
+}

--- a/tests/unit/download-gateway/PeopleRepositoryTest.php
+++ b/tests/unit/download-gateway/PeopleRepositoryTest.php
@@ -41,9 +41,9 @@ class PeopleRepositoryTest extends TestCase {
 
 	public function test_upsert_inserts_new_person_and_returns_id(): void {
 		/** @var \Mockery\MockInterface&\wpdb $wpdb */
-		$wpdb             = Mockery::mock( 'wpdb' );
-		$wpdb->prefix     = 'wp_';
-		$wpdb->insert_id  = 7;
+		$wpdb            = Mockery::mock( 'wpdb' );
+		$wpdb->prefix    = 'wp_';
+		$wpdb->insert_id = 7;
 		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'SELECT_SQL' );
 		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( null );
 		$wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );

--- a/wp-content/plugins/download-gateway/assets/css/gateway-modal.css
+++ b/wp-content/plugins/download-gateway/assets/css/gateway-modal.css
@@ -1,0 +1,113 @@
+/* Gateway modal — download gate UI */
+
+#gateway-overlay {
+	display: none;
+	position: fixed;
+	inset: 0;
+	background: rgba( 0, 0, 0, 0.55 );
+	z-index: 9999;
+	align-items: center;
+	justify-content: center;
+}
+
+#gateway-overlay.is-open {
+	display: flex;
+}
+
+#gateway-modal {
+	position: relative;
+	background: #fff;
+	border-radius: 4px;
+	padding: 2rem;
+	width: min( 420px, 92vw );
+	box-shadow: 0 8px 32px rgba( 0, 0, 0, 0.18 );
+}
+
+#gateway-modal-title {
+	margin: 0 0 0.5rem;
+	font-size: 1.25rem;
+}
+
+#gateway-modal-desc {
+	margin: 0 0 1.25rem;
+	font-size: 0.875rem;
+	color: #555;
+}
+
+#gateway-form label {
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 600;
+	margin: 0.75rem 0 0.25rem;
+}
+
+#gateway-form label.gateway-consent {
+	font-weight: 400;
+	display: flex;
+	align-items: flex-start;
+	gap: 0.4rem;
+	margin-top: 1rem;
+}
+
+#gateway-form input[type="text"],
+#gateway-form input[type="email"] {
+	width: 100%;
+	box-sizing: border-box;
+	padding: 0.45rem 0.6rem;
+	border: 1px solid #bbb;
+	border-radius: 3px;
+	font-size: 0.9rem;
+}
+
+#gateway-error {
+	min-height: 1.25rem;
+	margin: 0.75rem 0 0;
+	font-size: 0.875rem;
+	color: #c00;
+}
+
+.gateway-actions {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-top: 1rem;
+}
+
+#gateway-submit {
+	padding: 0.6rem 1rem;
+	background: #1a1a1a;
+	color: #fff;
+	border: none;
+	border-radius: 3px;
+	font-size: 0.9rem;
+	cursor: pointer;
+}
+
+#gateway-submit:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+#gateway-skip {
+	background: none;
+	border: none;
+	color: #555;
+	font-size: 0.8rem;
+	cursor: pointer;
+	text-decoration: underline;
+	padding: 0;
+	text-align: left;
+}
+
+#gateway-close {
+	position: absolute;
+	top: 0.75rem;
+	right: 0.75rem;
+	background: none;
+	border: none;
+	font-size: 1.25rem;
+	line-height: 1;
+	cursor: pointer;
+	color: #888;
+	padding: 0.25rem 0.4rem;
+}

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -8,6 +8,23 @@
 	}
 
 	// -------------------------------------------------------------------------
+	// Cookie helpers
+	// -------------------------------------------------------------------------
+
+	function getCookie( name ) {
+		var match = document.cookie.match(
+			new RegExp( '(?:^|; )' + name.replace( /[\.$?*|{}\(\)\[\]\\/\+^]/g, '\\$&' ) + '=([^;]*)' )
+		);
+		return match ? decodeURIComponent( match[ 1 ] ) : null;
+	}
+
+	function setCookie( name, value, days ) {
+		var expires = new Date( Date.now() + days * 864e5 ).toUTCString();
+		document.cookie = name + '=' + encodeURIComponent( value ) +
+			'; expires=' + expires + '; path=/; SameSite=Lax';
+	}
+
+	// -------------------------------------------------------------------------
 	// Modal DOM
 	// -------------------------------------------------------------------------
 
@@ -44,7 +61,7 @@
 				'<p id="gateway-error" role="alert" aria-live="assertive"></p>' +
 				'<div class="gateway-actions">' +
 					'<button id="gateway-submit" type="submit">Download</button>' +
-					'<button id="gateway-skip" type="button">Skip &mdash; download without sharing</button>' +
+					'<button id="gateway-skip" type="button">Download without sharing</button>' +
 				'</div>' +
 			'</form>';
 
@@ -180,10 +197,11 @@
 					return;
 				}
 				var directUrl = currentDirectUrl;
+				setCookie( 'gateway_gated', result.data.person_id, 30 );
 				closeModal();
 				var token = result.data.token;
 				if ( token ) {
-					redirect( gatewaySettings.downloadBase + '/' + token );
+					downloadViaToken( token, directUrl );
 				} else {
 					// Honeypot hit — silently redirect to direct URL
 					redirect( directUrl );
@@ -203,6 +221,71 @@
 		window.location.href = url;
 	}
 
+	/**
+	 * Consume a download token and navigate directly to the resolved file URL.
+	 *
+	 * Fetches the token endpoint with ?format=json so the server marks the token
+	 * as used and returns the file URL as JSON rather than a 302 redirect. This
+	 * avoids leaving an intermediate token URL in the browser's history stack.
+	 * Falls back to a direct token-URL navigation if the JSON request fails.
+	 *
+	 * @param {string} token      64-char hex download token.
+	 * @param {string} fallback   URL to navigate to if the JSON request fails.
+	 */
+	function downloadViaToken( token, fallback ) {
+		fetch( gatewaySettings.downloadBase + '/' + token + '?format=json', {
+			method:      'GET',
+			credentials: 'same-origin',
+			headers:     { 'X-WP-Nonce': gatewaySettings.restNonce },
+		} )
+			.then( function ( res ) { return res.json().then( function ( data ) { return { ok: res.ok, data: data }; } ); } )
+			.then( function ( result ) {
+				redirect( result.ok && result.data.url ? result.data.url : fallback );
+			} )
+			.catch( function () {
+				redirect( fallback );
+			} );
+	}
+
+	/**
+	 * Silent passthrough for returning visitors who already submitted the gate form.
+	 * Fires a token-request POST without showing the modal.
+	 * Falls back to the modal if the server rejects the passthrough
+	 * (e.g. person was anonymized).
+	 */
+	function doSilentPassthrough( postId, policy, personId, directUrl ) {
+		var body = new URLSearchParams( {
+			post_id:      postId,
+			_passthrough: personId,
+			nonce:        gatewaySettings.nonce,
+			_hp:          '',
+		} );
+
+		fetch( gatewaySettings.apiUrl, {
+			method:      'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				'X-WP-Nonce':   gatewaySettings.restNonce,
+			},
+			body: body.toString(),
+		} )
+			.then( function ( res ) { return res.json().then( function ( data ) { return { ok: res.ok, data: data }; } ); } )
+			.then( function ( result ) {
+				if ( ! result.ok ) {
+					// Passthrough rejected — show gate form.
+					openModal( postId, policy, directUrl );
+					return;
+				}
+				setCookie( 'gateway_gated', result.data.person_id, 30 );
+				downloadViaToken( result.data.token, directUrl );
+			} )
+			.catch( function () {
+				// Network error — fall back to modal.
+				openModal( postId, policy, directUrl );
+			} );
+	}
+
 	document.addEventListener( 'click', function ( e ) {
 		var link = e.target.closest( '.gateway-download-link' );
 		if ( ! link ) {
@@ -211,11 +294,17 @@
 
 		var policy = link.dataset.policy;
 		if ( ! policy || policy === 'none' ) {
-			// No gate — let browser follow the link naturally
+			// No gate — let browser follow the link naturally.
 			return;
 		}
 
 		e.preventDefault();
-		openModal( link.dataset.postId, policy, link.href );
+
+		var personId = getCookie( 'gateway_gated' );
+		if ( personId ) {
+			doSilentPassthrough( link.dataset.postId, policy, personId, link.href );
+		} else {
+			openModal( link.dataset.postId, policy, link.href );
+		}
 	} );
 }() );

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -120,8 +120,9 @@
 		closeBtn.addEventListener( 'click', closeModal );
 
 		skipBtn.addEventListener( 'click', function () {
+			var url = currentDirectUrl;
 			closeModal();
-			redirect( currentDirectUrl );
+			redirect( url );
 		} );
 
 		form.addEventListener( 'submit', function ( e ) {
@@ -163,9 +164,10 @@
 		} );
 
 		fetch( gatewaySettings.apiUrl, {
-			method:  'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body:    body.toString(),
+			method:      'POST',
+			credentials: 'same-origin',
+			headers:     { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body:        body.toString(),
 		} )
 			.then( function ( res ) { return res.json().then( function ( data ) { return { ok: res.ok, data: data }; } ); } )
 			.then( function ( result ) {
@@ -174,13 +176,14 @@
 					showError( result.data.message || 'Something went wrong. Please try again.' );
 					return;
 				}
+				var directUrl = currentDirectUrl;
 				closeModal();
 				var token = result.data.token;
 				if ( token ) {
 					redirect( gatewaySettings.downloadBase + '/' + token );
 				} else {
 					// Honeypot hit — silently redirect to direct URL
-					redirect( currentDirectUrl );
+					redirect( directUrl );
 				}
 			} )
 			.catch( function () {

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -1,0 +1,215 @@
+/* global gatewaySettings */
+( function () {
+	'use strict';
+
+	// gatewaySettings is localized by PHP: { nonce, apiUrl, downloadBase }
+	if ( typeof gatewaySettings === 'undefined' ) {
+		return;
+	}
+
+	// -------------------------------------------------------------------------
+	// Modal DOM
+	// -------------------------------------------------------------------------
+
+	var modal, overlay, form, nameField, emailField, consentField,
+		honeypotField, errorMsg, submitBtn, skipBtn, closeBtn;
+
+	function buildModal() {
+		overlay = document.createElement( 'div' );
+		overlay.id = 'gateway-overlay';
+		overlay.setAttribute( 'role', 'dialog' );
+		overlay.setAttribute( 'aria-modal', 'true' );
+		overlay.setAttribute( 'aria-labelledby', 'gateway-modal-title' );
+
+		modal = document.createElement( 'div' );
+		modal.id = 'gateway-modal';
+
+		modal.innerHTML =
+			'<button id="gateway-close" aria-label="Close">&times;</button>' +
+			'<h2 id="gateway-modal-title">Download this resource</h2>' +
+			'<p id="gateway-modal-desc">Share your name and email to download. Wikitongues will occasionally send you updates about our work — you can unsubscribe at any time.</p>' +
+			'<form id="gateway-form" novalidate>' +
+				'<label for="gateway-name">Name <span aria-hidden="true">*</span></label>' +
+				'<input id="gateway-name" name="name" type="text" autocomplete="name" required />' +
+				'<label for="gateway-email">Email <span aria-hidden="true">*</span></label>' +
+				'<input id="gateway-email" name="email" type="email" autocomplete="email" required />' +
+				'<label class="gateway-consent">' +
+					'<input id="gateway-consent" name="consent_download" type="checkbox" />' +
+					' I agree to receive occasional updates from Wikitongues' +
+				'</label>' +
+				// Honeypot — hidden from real users
+				'<div style="display:none" aria-hidden="true">' +
+					'<input id="gateway-hp" name="_hp" type="text" tabindex="-1" autocomplete="off" />' +
+				'</div>' +
+				'<p id="gateway-error" role="alert" aria-live="assertive"></p>' +
+				'<div class="gateway-actions">' +
+					'<button id="gateway-submit" type="submit">Download</button>' +
+					'<button id="gateway-skip" type="button">Skip &mdash; download without sharing</button>' +
+				'</div>' +
+			'</form>';
+
+		overlay.appendChild( modal );
+		document.body.appendChild( overlay );
+
+		form        = document.getElementById( 'gateway-form' );
+		nameField   = document.getElementById( 'gateway-name' );
+		emailField  = document.getElementById( 'gateway-email' );
+		consentField = document.getElementById( 'gateway-consent' );
+		honeypotField = document.getElementById( 'gateway-hp' );
+		errorMsg    = document.getElementById( 'gateway-error' );
+		submitBtn   = document.getElementById( 'gateway-submit' );
+		skipBtn     = document.getElementById( 'gateway-skip' );
+		closeBtn    = document.getElementById( 'gateway-close' );
+	}
+
+	// -------------------------------------------------------------------------
+	// Modal open / close
+	// -------------------------------------------------------------------------
+
+	var currentPostId = null;
+	var currentDirectUrl = null;
+
+	function openModal( postId, policy, directUrl ) {
+		if ( ! modal ) {
+			buildModal();
+			attachModalEvents();
+		}
+
+		currentPostId    = postId;
+		currentDirectUrl = directUrl;
+
+		errorMsg.textContent = '';
+		form.reset();
+		setLoading( false );
+
+		// Skip button only shown for soft gate
+		skipBtn.style.display = policy === 'soft' ? '' : 'none';
+		closeBtn.style.display = policy === 'soft' ? '' : 'none';
+
+		overlay.classList.add( 'is-open' );
+		nameField.focus();
+	}
+
+	function closeModal() {
+		overlay.classList.remove( 'is-open' );
+		currentPostId    = null;
+		currentDirectUrl = null;
+	}
+
+	function setLoading( loading ) {
+		submitBtn.disabled = loading;
+		submitBtn.textContent = loading ? 'Downloading\u2026' : 'Download';
+	}
+
+	function showError( msg ) {
+		errorMsg.textContent = msg;
+	}
+
+	// -------------------------------------------------------------------------
+	// Event wiring
+	// -------------------------------------------------------------------------
+
+	function attachModalEvents() {
+		// Close on overlay click (soft gate only — hard gate has no close btn)
+		overlay.addEventListener( 'click', function ( e ) {
+			if ( e.target === overlay && skipBtn.style.display !== 'none' ) {
+				closeModal();
+			}
+		} );
+
+		closeBtn.addEventListener( 'click', closeModal );
+
+		skipBtn.addEventListener( 'click', function () {
+			closeModal();
+			redirect( currentDirectUrl );
+		} );
+
+		form.addEventListener( 'submit', function ( e ) {
+			e.preventDefault();
+			handleSubmit();
+		} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Form submission
+	// -------------------------------------------------------------------------
+
+	function handleSubmit() {
+		var name    = nameField.value.trim();
+		var email   = emailField.value.trim();
+		var consent = consentField.checked;
+
+		if ( ! name ) {
+			showError( 'Please enter your name.' );
+			nameField.focus();
+			return;
+		}
+		if ( ! email ) {
+			showError( 'Please enter your email address.' );
+			emailField.focus();
+			return;
+		}
+
+		setLoading( true );
+		showError( '' );
+
+		var body = new URLSearchParams( {
+			post_id:          currentPostId,
+			name:             name,
+			email:            email,
+			consent_download: consent ? '1' : '0',
+			nonce:            gatewaySettings.nonce,
+			_hp:              honeypotField.value,
+		} );
+
+		fetch( gatewaySettings.apiUrl, {
+			method:  'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body:    body.toString(),
+		} )
+			.then( function ( res ) { return res.json().then( function ( data ) { return { ok: res.ok, data: data }; } ); } )
+			.then( function ( result ) {
+				setLoading( false );
+				if ( ! result.ok ) {
+					showError( result.data.message || 'Something went wrong. Please try again.' );
+					return;
+				}
+				closeModal();
+				var token = result.data.token;
+				if ( token ) {
+					redirect( gatewaySettings.downloadBase + '/' + token );
+				} else {
+					// Honeypot hit — silently redirect to direct URL
+					redirect( currentDirectUrl );
+				}
+			} )
+			.catch( function () {
+				setLoading( false );
+				showError( 'A network error occurred. Please try again.' );
+			} );
+	}
+
+	// -------------------------------------------------------------------------
+	// Click interception
+	// -------------------------------------------------------------------------
+
+	function redirect( url ) {
+		window.location.href = url;
+	}
+
+	document.addEventListener( 'click', function ( e ) {
+		var link = e.target.closest( '.gateway-download-link' );
+		if ( ! link ) {
+			return;
+		}
+
+		var policy = link.dataset.policy;
+		if ( ! policy || policy === 'none' ) {
+			// No gate — let browser follow the link naturally
+			return;
+		}
+
+		e.preventDefault();
+		openModal( link.dataset.postId, policy, link.href );
+	} );
+}() );

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -166,7 +166,10 @@
 		fetch( gatewaySettings.apiUrl, {
 			method:      'POST',
 			credentials: 'same-origin',
-			headers:     { 'Content-Type': 'application/x-www-form-urlencoded' },
+			headers:     {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				'X-WP-Nonce':   gatewaySettings.restNonce,
+			},
 			body:        body.toString(),
 		} )
 			.then( function ( res ) { return res.json().then( function ( data ) { return { ok: res.ok, data: data }; } ); } )

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -115,6 +115,7 @@ add_action(
 			'gatewaySettings',
 			[
 				'nonce'        => wp_create_nonce( 'gateway_gate' ),
+				'restNonce'    => wp_create_nonce( 'wp_rest' ),
 				'apiUrl'       => rest_url( GATEWAY_REST_NAMESPACE . '/gate' ),
 				'downloadBase' => rest_url( GATEWAY_REST_NAMESPACE . '/download' ),
 			]

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -46,7 +46,6 @@ require_once GATEWAY_DIR . 'includes/interface-file-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-document-file-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-file-resolver-registry.php';
 require_once GATEWAY_DIR . 'includes/class-download-controller.php';
-require_once GATEWAY_DIR . 'includes/class-acf-fields.php';
 require_once GATEWAY_DIR . 'includes/class-resource-metabox.php';
 require_once GATEWAY_DIR . 'includes/class-download-shortcode.php';
 require_once GATEWAY_DIR . 'includes/class-people-repository.php';
@@ -126,6 +125,6 @@ add_action(
 // Register file resolvers for supported post types.
 FileResolverRegistry::register( 'document_files', new DocumentFileResolver() );
 
-add_action( 'acf/init', __NAMESPACE__ . '\Acf_Fields::register' );
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\Resource_Metabox::register' );
+add_action( 'save_post', __NAMESPACE__ . '\Resource_Metabox::save' );
 Download_Shortcode::register();

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -46,6 +46,9 @@ require_once GATEWAY_DIR . 'includes/interface-file-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-document-file-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-file-resolver-registry.php';
 require_once GATEWAY_DIR . 'includes/class-download-controller.php';
+require_once GATEWAY_DIR . 'includes/class-acf-fields.php';
+require_once GATEWAY_DIR . 'includes/class-resource-metabox.php';
+require_once GATEWAY_DIR . 'includes/class-download-shortcode.php';
 require_once GATEWAY_DIR . 'includes/admin/class-settings-page.php';
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\Activator::activate' );
@@ -86,3 +89,7 @@ add_action(
 
 // Register file resolvers for supported post types.
 FileResolverRegistry::register( 'document_files', new DocumentFileResolver() );
+
+add_action( 'acf/init', __NAMESPACE__ . '\Acf_Fields::register' );
+add_action( 'add_meta_boxes', __NAMESPACE__ . '\Resource_Metabox::register' );
+Download_Shortcode::register();

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -49,6 +49,8 @@ require_once GATEWAY_DIR . 'includes/class-download-controller.php';
 require_once GATEWAY_DIR . 'includes/class-acf-fields.php';
 require_once GATEWAY_DIR . 'includes/class-resource-metabox.php';
 require_once GATEWAY_DIR . 'includes/class-download-shortcode.php';
+require_once GATEWAY_DIR . 'includes/class-people-repository.php';
+require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
 require_once GATEWAY_DIR . 'includes/admin/class-settings-page.php';
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\Activator::activate' );
@@ -83,7 +85,41 @@ add_action(
 		// @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php)
 		if ( GATEWAY_ENABLED ) {
 			( new DownloadController() )->register_routes();
+			( new GateController() )->register_routes();
 		}
+	}
+);
+
+add_action(
+	'wp_enqueue_scripts',
+	function (): void {
+		// @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php)
+		if ( ! GATEWAY_ENABLED ) {
+			return;
+		}
+		// @phpstan-ignore-next-line (unreachable only in static analysis — runtime value differs)
+		wp_enqueue_style(
+			'gateway-modal',
+			plugins_url( 'assets/css/gateway-modal.css', GATEWAY_FILE ),
+			[],
+			GATEWAY_VERSION
+		);
+		wp_enqueue_script(
+			'gateway-modal',
+			plugins_url( 'assets/js/gateway-modal.js', GATEWAY_FILE ),
+			[],
+			GATEWAY_VERSION,
+			true
+		);
+		wp_localize_script(
+			'gateway-modal',
+			'gatewaySettings',
+			[
+				'nonce'        => wp_create_nonce( 'gateway_gate' ),
+				'apiUrl'       => rest_url( GATEWAY_REST_NAMESPACE . '/gate' ),
+				'downloadBase' => rest_url( GATEWAY_REST_NAMESPACE . '/download' ),
+			]
+		);
 	}
 );
 

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -2,9 +2,9 @@
 /**
  * Settings_Page — admin UI for the download gateway.
  *
- * Sub-phase 0: registers the menu entry and renders a placeholder.
- * Sub-phases 2a/2b will add real fields (global gate policy, retention months,
- * Dropbox credentials, GA4 measurement ID, etc.).
+ * Settings → Download Gateway. Currently exposes the global gate policy
+ * (the site-wide default that PolicyResolver falls back to when no
+ * per-resource or per-taxonomy override is set).
  *
  * @package WT\DownloadGateway
  */
@@ -12,6 +12,9 @@
 namespace WT\DownloadGateway;
 
 class Settings_Page {
+
+	private const NONCE_ACTION = 'gateway_settings_save';
+	private const NONCE_FIELD  = 'gateway_settings_nonce';
 
 	public static function register(): void {
 		add_options_page(
@@ -23,10 +26,41 @@ class Settings_Page {
 		);
 	}
 
+	public static function save(): void {
+		if (
+			! isset( $_POST[ self::NONCE_FIELD ] ) ||
+			! wp_verify_nonce( sanitize_key( $_POST[ self::NONCE_FIELD ] ), self::NONCE_ACTION )
+		) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$allowed = [ 'none', 'soft', 'hard' ];
+		$policy  = isset( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
+			? sanitize_key( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
+			: SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
+
+		if ( ! in_array( $policy, $allowed, true ) ) {
+			$policy = SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
+		}
+
+		update_option( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $policy );
+	}
+
 	public static function render(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
+
+		// Handle form submission directly (no options-general.php redirect needed).
+		if ( isset( $_POST[ self::NONCE_FIELD ] ) ) {
+			self::save();
+		}
+
+		$current_policy = SettingsRepository::get_global_gate_policy();
 		?>
 		<div class="wrap">
 			<h1>Download Gateway</h1>
@@ -45,11 +79,31 @@ class Settings_Page {
 				</p>
 			</div>
 			<?php endif; ?>
-			<hr>
-			<p style="color:#666;">
-				Gateway settings (global gate policy, retention period, Dropbox credentials,
-				GA4 measurement ID) will appear here in a future release.
-			</p>
+
+			<form method="post">
+				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD ); ?>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row">
+							<label for="gateway_global_gate_policy">Global gate policy</label>
+						</th>
+						<td>
+							<select name="<?php echo esc_attr( SettingsRepository::OPTION_GLOBAL_GATE_POLICY ); ?>" id="gateway_global_gate_policy">
+								<option value="none" <?php selected( $current_policy, 'none' ); ?>>None — direct redirect, no gate</option>
+								<option value="soft" <?php selected( $current_policy, 'soft' ); ?>>Soft gate — skippable email prompt</option>
+								<option value="hard" <?php selected( $current_policy, 'hard' ); ?>>Hard gate — email required</option>
+							</select>
+							<p class="description">
+								Site-wide default. Individual resources can override this via the
+								<strong>Download Gateway</strong> metabox in the post editor.
+							</p>
+						</td>
+					</tr>
+				</table>
+
+				<?php submit_button( 'Save settings' ); ?>
+			</form>
 		</div>
 		<?php
 	}

--- a/wp-content/plugins/download-gateway/includes/class-acf-fields.php
+++ b/wp-content/plugins/download-gateway/includes/class-acf-fields.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Acf_Fields — registers gateway ACF fields programmatically.
+ *
+ * Adds a "Download Gateway" field group to all post types that have a
+ * registered FileResolver. The group exposes:
+ *   - _gateway_gate_policy  per-resource override (none / soft / hard / inherit)
+ *
+ * Registered via acf_add_local_field_group() so no ACF JSON is required
+ * in the theme, and no DB write happens on activation.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class Acf_Fields {
+
+	public static function register(): void {
+		if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+			return;
+		}
+
+		$post_types = FileResolverRegistry::registered_post_types();
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		$location = array_map(
+			fn( string $pt ) => array( array( 'param' => 'post_type', 'operator' => '==', 'value' => $pt ) ),
+			$post_types
+		);
+
+		acf_add_local_field_group(
+			array(
+				'key'      => 'group_gateway_resource',
+				'title'    => 'Download Gateway',
+				'fields'   => array(
+					array(
+						'key'           => 'field_gateway_gate_policy',
+						'label'         => 'Gate policy override',
+						'name'          => '_gateway_gate_policy',
+						'type'          => 'select',
+						'instructions'  => 'Override the global gate policy for this resource. "Inherit" uses the global default.',
+						'required'      => 0,
+						'choices'       => array(
+							''     => 'Inherit (use global default)',
+							'none' => 'None — direct redirect, no gate',
+							'soft' => 'Soft gate — skippable email prompt',
+							'hard' => 'Hard gate — email required',
+						),
+						'default_value' => '',
+						'allow_null'    => 1,
+						'multiple'      => 0,
+						'ui'            => 0,
+						'return_format' => 'value',
+					),
+				),
+				'location' => $location,
+				'position' => 'side',
+				'style'    => 'default',
+				'active'   => true,
+			)
+		);
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-download-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-controller.php
@@ -29,9 +29,13 @@ class DownloadController {
 				'callback'            => [ $this, 'handle' ],
 				'permission_callback' => '__return_true',
 				'args'                => [
-					'id' => [
+					'id'     => [
 						'required'          => true,
 						'validate_callback' => fn( $v ) => is_string( $v ) && strlen( $v ) > 0,
+					],
+					'format' => [
+						'required'          => false,
+						'validate_callback' => fn( $v ) => in_array( $v, [ 'json' ], true ),
 					],
 				],
 			]
@@ -39,16 +43,21 @@ class DownloadController {
 	}
 
 	/**
-	 * REST callback — resolves the download and sends a 302 redirect.
+	 * REST callback — resolves the download, then either sends a 302 redirect
+	 * (default) or returns JSON {url} when ?format=json is requested.
 	 *
-	 * Not unit-tested: this method's only job is to call resolve() and
-	 * redirect. All business logic lives in resolve().
+	 * The JSON format is used by the JS modal to avoid leaving an intermediate
+	 * token URL in the browser's history stack.
+	 *
+	 * Not unit-tested: this method's only job is to call resolve() and respond.
+	 * All business logic lives in resolve().
 	 *
 	 * @param \WP_REST_Request $request
-	 * @return never|\WP_Error
+	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public function handle( \WP_REST_Request $request ): \WP_Error {
+	public function handle( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
 		$id     = $request->get_param( 'id' );
+		$format = (string) ( $request->get_param( 'format' ) ?? '' );
 		$result = $this->resolve( $id, $_COOKIE, $_SERVER );
 
 		if ( is_wp_error( $result ) ) {
@@ -57,6 +66,10 @@ class DownloadController {
 
 		$visitor_id = VisitorId::from_cookies( $_COOKIE ) ?? VisitorId::generate();
 		VisitorId::set_cookie( $visitor_id );
+
+		if ( 'json' === $format ) {
+			return new \WP_REST_Response( [ 'url' => $result ], 200 );
+		}
 
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
 		header( 'Pragma: no-cache' );

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Download_Shortcode — [gateway_download] shortcode.
+ *
+ * Usage:
+ *   [gateway_download id="42"]
+ *   [gateway_download id="42" label="Download PDF"]
+ *
+ * Renders an anchor tag pointing to the gateway download endpoint.
+ * Falls back gracefully when the post ID is missing or invalid.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class Download_Shortcode {
+
+	public static function register(): void {
+		add_shortcode( 'gateway_download', array( self::class, 'render' ) );
+	}
+
+	/**
+	 * @param array<string,string>|string $atts
+	 */
+	public static function render( $atts ): string {
+		$atts = shortcode_atts(
+			array(
+				'id'    => '',
+				'label' => 'Download',
+			),
+			$atts,
+			'gateway_download'
+		);
+
+		$post_id = (int) $atts['id'];
+		if ( $post_id <= 0 ) {
+			return '<!-- gateway_download: missing or invalid id -->';
+		}
+
+		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+
+		return sprintf(
+			'<a href="%s" class="gateway-download-link">%s</a>',
+			esc_url( $url ),
+			esc_html( $atts['label'] )
+		);
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -38,11 +38,14 @@ class Download_Shortcode {
 			return '<!-- gateway_download: missing or invalid id -->';
 		}
 
-		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+		$url    = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+		$policy = PolicyResolver::resolve( $post_id );
 
 		return sprintf(
-			'<a href="%s" class="gateway-download-link">%s</a>',
+			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s">%s</a>',
 			esc_url( $url ),
+			$post_id,
+			esc_attr( $policy ),
 			esc_html( $atts['label'] )
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/class-file-resolver-registry.php
+++ b/wp-content/plugins/download-gateway/includes/class-file-resolver-registry.php
@@ -68,6 +68,15 @@ class FileResolverRegistry {
 	}
 
 	/**
+	 * Return all registered post type slugs.
+	 *
+	 * @return string[]
+	 */
+	public static function registered_post_types(): array {
+		return array_keys( self::$resolvers );
+	}
+
+	/**
 	 * Clear all registered resolvers.
 	 *
 	 * For use in tests only — allows each test to start from a clean registry.

--- a/wp-content/plugins/download-gateway/includes/class-gate-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-gate-controller.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * GateController — handles gate form submissions.
+ *
+ * Registers POST /wp-json/gateway/v1/gate. The testable logic lives in
+ * submit() (same pattern as DownloadController::resolve()). handle() is an
+ * untested wrapper that reads the REST request and returns a WP_REST_Response.
+ *
+ * Gate flow:
+ *   1. JS sends POST with {post_id, email, name, consent_download, nonce, _hp}
+ *   2. Server validates nonce, honeypot, rate limit, and field values.
+ *   3. Person is upserted into wp_gateway_people.
+ *   4. A one-time download token is created and returned.
+ *   5. JS redirects to GET /gateway/v1/download/{token}.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class GateController {
+
+	/** Maximum gate submissions per IP per hour. */
+	private const RATE_LIMIT = 10;
+
+	/** Rate-limit window in seconds. */
+	private const RATE_WINDOW = 3600;
+
+	public function register_routes(): void {
+		register_rest_route(
+			GATEWAY_REST_NAMESPACE,
+			'/gate',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ $this, 'handle' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * REST callback — not unit tested.
+	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		$result = $this->submit(
+			(int) ( $request->get_param( 'post_id' ) ?? 0 ),
+			(string) ( $request->get_param( 'email' ) ?? '' ),
+			(string) ( $request->get_param( 'name' ) ?? '' ),
+			(bool) ( $request->get_param( 'consent_download' ) ?? false ),
+			(string) ( $request->get_param( 'nonce' ) ?? '' ),
+			(string) ( $request->get_param( '_hp' ) ?? '' ),
+			$_COOKIE,
+			$_SERVER
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new \WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * Process a gate submission. Returns an array with the download token on
+	 * success, or a WP_Error on failure.
+	 *
+	 * Honeypot hits return a silent success (fake token = null) to avoid
+	 * giving bots any signal about the rejection.
+	 *
+	 * @param int                  $post_id          Post ID of the resource.
+	 * @param string               $email            Submitted email address.
+	 * @param string               $name             Submitted name.
+	 * @param bool                 $consent_download Whether the user consented.
+	 * @param string               $nonce            WP nonce value.
+	 * @param string               $honeypot         Hidden spam-trap field value.
+	 * @param array<string,mixed>  $cookies          Cookie values (injected for testing).
+	 * @param array<string,mixed>  $server           Server vars (injected for testing).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function submit(
+		int $post_id,
+		string $email,
+		string $name,
+		bool $consent_download,
+		string $nonce,
+		string $honeypot,
+		array $cookies = [],
+		array $server = []
+	): array|\WP_Error {
+
+		// Honeypot — bots fill hidden fields; silently succeed.
+		if ( '' !== $honeypot ) {
+			return [ 'token' => null ];
+		}
+
+		// Nonce verification.
+		if ( ! wp_verify_nonce( $nonce, 'gateway_gate' ) ) {
+			return new \WP_Error( 'invalid_nonce', 'Request could not be verified.', [ 'status' => 403 ] );
+		}
+
+		// Rate limiting by IP hash.
+		$ip_hash  = IpHasher::hash_from_server( $server );
+		$rate_key = 'gw_rate_' . substr( $ip_hash, 0, 28 );
+		$count    = (int) get_transient( $rate_key );
+		if ( $count >= self::RATE_LIMIT ) {
+			return new \WP_Error( 'rate_limited', 'Too many requests. Please try again later.', [ 'status' => 429 ] );
+		}
+		set_transient( $rate_key, $count + 1, self::RATE_WINDOW );
+
+		// Field validation.
+		if ( $post_id <= 0 ) {
+			return new \WP_Error( 'invalid_post_id', 'Invalid resource.', [ 'status' => 400 ] );
+		}
+		if ( ! is_email( $email ) ) {
+			return new \WP_Error( 'invalid_email', 'A valid email address is required.', [ 'status' => 400 ] );
+		}
+		$name = trim( $name );
+		if ( '' === $name ) {
+			return new \WP_Error( 'invalid_name', 'Your name is required.', [ 'status' => 400 ] );
+		}
+
+		// Upsert person.
+		$person_id = PeopleRepository::upsert( $email, $name, $consent_download );
+		if ( false === $person_id ) {
+			return new \WP_Error( 'db_error', 'Could not save your information. Please try again.', [ 'status' => 500 ] );
+		}
+
+		// Create one-time download token tied to this person.
+		$visitor_id = VisitorId::from_cookies( $cookies );
+		$token      = TokenRepository::create( $post_id, TokenRepository::TTL_DEFAULT, $visitor_id, $person_id );
+
+		return [ 'token' => $token ];
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-people-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-people-repository.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * PeopleRepository — CRUD on wp_gateway_people.
+ *
+ * People are identified by the SHA-256 hash of their lowercase, trimmed email
+ * address. Upsert is the primary operation: insert on first capture, update
+ * name/consent on repeat submissions (e.g. upgraded consent).
+ *
+ * Anonymized records (is_anonymized = 1) are excluded from lookups so that
+ * a re-capture after anonymization creates a fresh record rather than
+ * resurrecting a deleted one.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class PeopleRepository {
+
+	/**
+	 * Upsert a person by email address.
+	 *
+	 * Returns the person_id on success, false on DB error.
+	 *
+	 * @param string $email            Raw email address.
+	 * @param string $name             Display name.
+	 * @param bool   $consent_download Consented to download-related comms.
+	 * @param bool   $consent_marketing Consented to marketing comms.
+	 * @return int|false
+	 */
+	public static function upsert(
+		string $email,
+		string $name,
+		bool $consent_download,
+		bool $consent_marketing = false
+	): int|false {
+		global $wpdb;
+
+		$table      = $wpdb->prefix . 'gateway_people';
+		$email_hash = self::hash_email( $email );
+
+		$existing_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$table} WHERE email_hash = %s AND is_anonymized = 0",
+				$email_hash
+			)
+		);
+
+		if ( null !== $existing_id ) {
+			$wpdb->update(
+				$table,
+				[
+					'name'               => sanitize_text_field( $name ),
+					'consent_download'   => $consent_download ? 1 : 0,
+					'consent_marketing'  => $consent_marketing ? 1 : 0,
+				],
+				[ 'id' => (int) $existing_id ]
+			);
+			return (int) $existing_id;
+		}
+
+		$result = $wpdb->insert(
+			$table,
+			[
+				'email_hash'         => $email_hash,
+				'email'              => sanitize_email( $email ),
+				'name'               => sanitize_text_field( $name ),
+				'consent_download'   => $consent_download ? 1 : 0,
+				'consent_marketing'  => $consent_marketing ? 1 : 0,
+				'is_anonymized'      => 0,
+				'created_at'         => current_time( 'mysql' ),
+			]
+		);
+
+		if ( false === $result ) {
+			return false;
+		}
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Find a non-anonymized person by email address.
+	 *
+	 * @param string $email Raw email address.
+	 * @return object|null
+	 */
+	public static function find_by_email( string $email ): ?object {
+		global $wpdb;
+
+		$table      = $wpdb->prefix . 'gateway_people';
+		$email_hash = self::hash_email( $email );
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$table} WHERE email_hash = %s AND is_anonymized = 0",
+				$email_hash
+			)
+		);
+
+		return $row ?: null;
+	}
+
+	/**
+	 * Hash an email address for storage and lookup.
+	 *
+	 * @param string $email Raw email address.
+	 * @return string 64-char lowercase hex SHA-256 hash.
+	 */
+	public static function hash_email( string $email ): string {
+		return hash( 'sha256', strtolower( trim( $email ) ) );
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Resource_Metabox — shows the gateway download URL in the post editor.
+ *
+ * Registers a read-only metabox on all CPTs that have a registered
+ * FileResolver. Content authors use this URL in links or the
+ * [gateway_download] shortcode. The URL never changes for a given post ID.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class Resource_Metabox {
+
+	public static function register(): void {
+		$post_types = FileResolverRegistry::registered_post_types();
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		add_meta_box(
+			'gateway_download_url',
+			'Download Gateway',
+			array( self::class, 'render' ),
+			$post_types,
+			'side',
+			'default'
+		);
+	}
+
+	public static function render( \WP_Post $post ): void {
+		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post->ID );
+		?>
+		<p style="margin:0 0 6px;font-size:11px;color:#646970;">
+			Use this URL wherever a download link is needed, or use the shortcode below.
+		</p>
+		<input
+			type="text"
+			readonly
+			value="<?php echo esc_attr( $url ); ?>"
+			style="width:100%;font-size:11px;"
+			onclick="this.select();"
+		/>
+		<p style="margin:6px 0 0;font-size:11px;color:#646970;">
+			Shortcode: <code>[gateway_download id="<?php echo esc_html( (string) $post->ID ); ?>"]</code>
+		</p>
+		<?php // @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php) ?>
+		<?php if ( ! GATEWAY_ENABLED ) : ?>
+		<p style="margin:6px 0 0;font-size:11px;color:#a00;">
+			Gateway is disabled. Enable it in wp-config.php to activate this URL.
+		</p>
+		<?php endif; ?>
+		<?php
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Resource_Metabox — shows the gateway download URL in the post editor.
+ * Resource_Metabox — single "Download Gateway" sidebar metabox.
  *
- * Registers a read-only metabox on all CPTs that have a registered
- * FileResolver. Content authors use this URL in links or the
- * [gateway_download] shortcode. The URL never changes for a given post ID.
+ * Consolidates the gate policy override select and the download URL/shortcode
+ * reference into one panel. Saves _gateway_gate_policy via save_post so there
+ * is no ACF dependency for this field.
  *
  * @package WT\DownloadGateway
  */
@@ -13,6 +13,9 @@ namespace WT\DownloadGateway;
 
 class Resource_Metabox {
 
+	private const NONCE_ACTION = 'gateway_resource_save';
+	private const NONCE_FIELD  = 'gateway_resource_nonce';
+
 	public static function register(): void {
 		$post_types = FileResolverRegistry::registered_post_types();
 		if ( empty( $post_types ) ) {
@@ -20,35 +23,71 @@ class Resource_Metabox {
 		}
 
 		add_meta_box(
-			'gateway_download_url',
+			'gateway_resource',
 			'Download Gateway',
-			array( self::class, 'render' ),
+			[ self::class, 'render' ],
 			$post_types,
 			'side',
 			'default'
 		);
 	}
 
+	public static function save( int $post_id ): void {
+		if (
+			! isset( $_POST[ self::NONCE_FIELD ] ) ||
+			! wp_verify_nonce( sanitize_key( $_POST[ self::NONCE_FIELD ] ), self::NONCE_ACTION )
+		) {
+			return;
+		}
+
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		$allowed = [ '', 'none', 'soft', 'hard' ];
+		$value   = isset( $_POST['_gateway_gate_policy'] )
+			? sanitize_key( $_POST['_gateway_gate_policy'] )
+			: '';
+
+		if ( ! in_array( $value, $allowed, true ) ) {
+			$value = '';
+		}
+
+		update_post_meta( $post_id, '_gateway_gate_policy', $value );
+	}
+
 	public static function render( \WP_Post $post ): void {
-		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post->ID );
+		wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD );
+
+		$policy = (string) get_post_meta( $post->ID, '_gateway_gate_policy', true );
+		$url    = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post->ID );
 		?>
-		<p style="margin:0 0 6px;font-size:11px;color:#646970;">
-			Use this URL wherever a download link is needed, or use the shortcode below.
-		</p>
+		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Gate policy</p>
+		<select name="_gateway_gate_policy" style="width:100%;margin-bottom:10px;">
+			<option value=""  <?php selected( $policy, '' ); ?>>Inherit (use global default)</option>
+			<option value="none" <?php selected( $policy, 'none' ); ?>>None — direct redirect</option>
+			<option value="soft" <?php selected( $policy, 'soft' ); ?>>Soft gate — skippable prompt</option>
+			<option value="hard" <?php selected( $policy, 'hard' ); ?>>Hard gate — email required</option>
+		</select>
+		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Download URL</p>
 		<input
 			type="text"
 			readonly
 			value="<?php echo esc_attr( $url ); ?>"
-			style="width:100%;font-size:11px;"
+			style="width:100%;font-size:11px;margin-bottom:6px;"
 			onclick="this.select();"
 		/>
-		<p style="margin:6px 0 0;font-size:11px;color:#646970;">
+		<p style="margin:0 0 6px;font-size:11px;color:#646970;">
 			Shortcode: <code>[gateway_download id="<?php echo esc_html( (string) $post->ID ); ?>"]</code>
 		</p>
 		<?php // @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php) ?>
 		<?php if ( ! GATEWAY_ENABLED ) : ?>
-		<p style="margin:6px 0 0;font-size:11px;color:#a00;">
-			Gateway is disabled. Enable it in wp-config.php to activate this URL.
+		<p style="margin:4px 0 0;font-size:11px;color:#a00;">
+			Gateway is disabled — enable in wp-config.php to activate this URL.
 		</p>
 		<?php endif; ?>
 		<?php


### PR DESCRIPTION
## Summary

- Plugin scaffold with `GATEWAY_ENABLED` feature flag, DB schema (4 tables), settings page
- Download endpoint `GET /gateway/v1/download/{post-id|token}` — signed expiring tokens, visitor cookie, click/redirect event logging, IP hashing
- Gate endpoint `POST /gateway/v1/gate` — soft (skippable) and hard (email required) modals, person upsert, one-time token issuance, nonce + rate limit + honeypot
- Per-resource gate policy metabox (consolidated) + global policy in Settings → Download Gateway
- `[gateway_download]` shortcode with policy-aware data attributes
- 70 unit tests (PHPStan clean, PHPCS clean)

## Test plan

- [ ] Activate plugin on staging
- [ ] Set `define('GATEWAY_ENABLED', true)` in wp-config.php
- [ ] Verify all policy permutations: file hard/soft/none/inherit × global hard/soft/none
- [ ] Verify person records created in `wp_gateway_people`
- [ ] Verify tokens marked used in `wp_gateway_tokens`
- [ ] Verify download events logged in `wp_gateway_download_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)