### PR TITLE
feat: gateway sub-phase 9 — retention automation

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,7 @@
   <file>wp-content/themes/blankslate-child</file>
   <file>wp-content/plugins/wt-gallery</file>
   <file>wp-content/plugins/typeahead/typeahead.php</file>
+  <file>wp-content/plugins/download-gateway</file>
   <file>tests</file>
 
   <!-- Exclusions -->

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,6 +26,11 @@ parameters:
 			path: tests/unit/download-gateway/GateControllerTest.php
 
 		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:once\\(\\)\\.$#"
+			count: 6
+			path: tests/unit/download-gateway/RetentionJobTest.php
+
+		-
 			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:twice\\(\\)\\.$#"
 			count: 1
 			path: tests/unit/download-gateway/GateControllerTest.php

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ require_once GATEWAY_DIR . 'includes/class-download-event-repository.php';
 require_once GATEWAY_DIR . 'includes/class-download-controller.php';
 require_once GATEWAY_DIR . 'includes/class-people-repository.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
+require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/integrations/acf-helpers.php';
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/template/search-filter.php';

--- a/tests/unit/download-gateway/RetentionJobTest.php
+++ b/tests/unit/download-gateway/RetentionJobTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use WT\DownloadGateway\RetentionJob;
+
+class RetentionJobTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// anonymize()
+	// -------------------------------------------------------------------------
+
+	public function test_anonymize_returns_count_of_anonymized_records(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'UPDATE_SQL' );
+		$wpdb->shouldReceive( 'query' )->once()->andReturn( 3 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-16 10:00:00' ) );
+		WP_Mock::userFunction( 'get_option', array( 'return' => 24 ) );
+		WP_Mock::userFunction( 'update_option', array( 'return' => true ) );
+
+		$this->assertSame( 3, RetentionJob::anonymize() );
+	}
+
+	public function test_anonymize_returns_zero_when_no_records_due(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'UPDATE_SQL' );
+		$wpdb->shouldReceive( 'query' )->once()->andReturn( 0 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-16 10:00:00' ) );
+		WP_Mock::userFunction( 'get_option', array( 'return' => 24 ) );
+		WP_Mock::userFunction( 'update_option', array( 'return' => true ) );
+
+		$this->assertSame( 0, RetentionJob::anonymize() );
+	}
+
+	public function test_anonymize_returns_zero_on_db_error(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'prepare' )->once()->andReturn( 'UPDATE_SQL' );
+		$wpdb->shouldReceive( 'query' )->once()->andReturn( false );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-16 10:00:00' ) );
+		WP_Mock::userFunction( 'get_option', array( 'return' => 24 ) );
+		WP_Mock::userFunction( 'update_option', array( 'return' => true ) );
+
+		$this->assertSame( 0, RetentionJob::anonymize() );
+	}
+}

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -50,6 +50,7 @@ require_once GATEWAY_DIR . 'includes/class-resource-metabox.php';
 require_once GATEWAY_DIR . 'includes/class-download-shortcode.php';
 require_once GATEWAY_DIR . 'includes/class-people-repository.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
+require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 require_once GATEWAY_DIR . 'includes/admin/class-settings-page.php';
 
 register_activation_hook( __FILE__, __NAMESPACE__ . '\Activator::activate' );
@@ -100,31 +101,38 @@ add_action(
 		wp_enqueue_style(
 			'gateway-modal',
 			plugins_url( 'assets/css/gateway-modal.css', GATEWAY_FILE ),
-			[],
+			array(),
 			GATEWAY_VERSION
 		);
 		wp_enqueue_script(
 			'gateway-modal',
 			plugins_url( 'assets/js/gateway-modal.js', GATEWAY_FILE ),
-			[],
+			array(),
 			GATEWAY_VERSION,
 			true
 		);
 		wp_localize_script(
 			'gateway-modal',
 			'gatewaySettings',
-			[
+			array(
 				'nonce'        => wp_create_nonce( 'gateway_gate' ),
 				'restNonce'    => wp_create_nonce( 'wp_rest' ),
 				'apiUrl'       => rest_url( GATEWAY_REST_NAMESPACE . '/gate' ),
 				'downloadBase' => rest_url( GATEWAY_REST_NAMESPACE . '/download' ),
-			]
+			)
 		);
 	}
 );
 
 // Register file resolvers for supported post types.
 FileResolverRegistry::register( 'document_files', new DocumentFileResolver() );
+
+add_action(
+	RetentionJob::CRON_HOOK,
+	function (): void {
+		RetentionJob::anonymize();
+	}
+);
 
 add_action( 'add_meta_boxes', __NAMESPACE__ . '\Resource_Metabox::register' );
 add_action( 'save_post', __NAMESPACE__ . '\Resource_Metabox::save' );

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -78,6 +78,7 @@ add_action(
 );
 
 add_action( 'admin_menu', __NAMESPACE__ . '\Settings_Page::register' );
+add_action( 'admin_init', __NAMESPACE__ . '\Settings_Page::handle_run_now_action' );
 
 add_action(
 	'rest_api_init',

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -2,9 +2,8 @@
 /**
  * Settings_Page — admin UI for the download gateway.
  *
- * Settings → Download Gateway. Currently exposes the global gate policy
- * (the site-wide default that PolicyResolver falls back to when no
- * per-resource or per-taxonomy override is set).
+ * Settings → Download Gateway. Exposes the global gate policy, the data
+ * retention window, and a manual run-now button for the retention job.
  *
  * @package WT\DownloadGateway
  */
@@ -13,8 +12,10 @@ namespace WT\DownloadGateway;
 
 class Settings_Page {
 
-	private const NONCE_ACTION = 'gateway_settings_save';
-	private const NONCE_FIELD  = 'gateway_settings_nonce';
+	private const NONCE_ACTION         = 'gateway_settings_save';
+	private const NONCE_FIELD          = 'gateway_settings_nonce';
+	private const NONCE_ACTION_RUN_NOW = 'gateway_retention_run';
+	private const NONCE_FIELD_RUN_NOW  = 'gateway_retention_nonce';
 
 	public static function register(): void {
 		add_options_page(
@@ -22,7 +23,7 @@ class Settings_Page {
 			'Download Gateway',
 			'manage_options',
 			'download-gateway',
-			[ self::class, 'render' ]
+			array( self::class, 'render' )
 		);
 	}
 
@@ -38,7 +39,7 @@ class Settings_Page {
 			return;
 		}
 
-		$allowed = [ 'none', 'soft', 'hard' ];
+		$allowed = array( 'none', 'soft', 'hard' );
 		$policy  = isset( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
 			? sanitize_key( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
 			: SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
@@ -48,6 +49,45 @@ class Settings_Page {
 		}
 
 		update_option( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $policy );
+
+		$retention_months = isset( $_POST[ SettingsRepository::OPTION_RETENTION_MONTHS ] )
+			? (int) $_POST[ SettingsRepository::OPTION_RETENTION_MONTHS ]
+			: SettingsRepository::DEFAULT_RETENTION_MONTHS;
+
+		if ( $retention_months <= 0 ) {
+			$retention_months = SettingsRepository::DEFAULT_RETENTION_MONTHS;
+		}
+
+		update_option( SettingsRepository::OPTION_RETENTION_MONTHS, $retention_months );
+	}
+
+	/**
+	 * Run the retention job immediately and redirect back with a status param.
+	 */
+	private static function handle_run_now(): void {
+		if (
+			! isset( $_POST[ self::NONCE_FIELD_RUN_NOW ] ) ||
+			! wp_verify_nonce( sanitize_key( $_POST[ self::NONCE_FIELD_RUN_NOW ] ), self::NONCE_ACTION_RUN_NOW )
+		) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$count = RetentionJob::anonymize();
+
+		wp_safe_redirect(
+			add_query_arg(
+				array(
+					'page'             => 'download-gateway',
+					'retention_result' => $count,
+				),
+				admin_url( 'options-general.php' )
+			)
+		);
+		exit;
 	}
 
 	public static function render(): void {
@@ -55,12 +95,21 @@ class Settings_Page {
 			return;
 		}
 
-		// Handle form submission directly (no options-general.php redirect needed).
+		// Handle run-now before any output — it redirects on success.
+		if ( isset( $_POST[ self::NONCE_FIELD_RUN_NOW ] ) ) {
+			self::handle_run_now();
+		}
+
+		// Handle settings form submission.
 		if ( isset( $_POST[ self::NONCE_FIELD ] ) ) {
 			self::save();
 		}
 
-		$current_policy = SettingsRepository::get_global_gate_policy();
+		$current_policy           = SettingsRepository::get_global_gate_policy();
+		$current_retention_months = SettingsRepository::get_retention_months();
+		$last_run                 = get_option( RetentionJob::OPTION_LAST_RUN, null );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$retention_result = isset( $_GET['retention_result'] ) ? (int) $_GET['retention_result'] : null;
 		?>
 		<div class="wrap">
 			<h1>Download Gateway</h1>
@@ -100,9 +149,59 @@ class Settings_Page {
 							</p>
 						</td>
 					</tr>
+					<tr>
+						<th scope="row">
+							<label for="gateway_retention_months">Data retention</label>
+						</th>
+						<td>
+							<input
+								type="number"
+								name="<?php echo esc_attr( SettingsRepository::OPTION_RETENTION_MONTHS ); ?>"
+								id="gateway_retention_months"
+								value="<?php echo esc_attr( (string) $current_retention_months ); ?>"
+								min="1"
+								max="120"
+								style="width:80px;"
+							/> months
+							<p class="description">
+								Email and name are nulled out after this many months.
+								The person record itself is kept so download history remains intact.
+							</p>
+						</td>
+					</tr>
 				</table>
 
 				<?php submit_button( 'Save settings' ); ?>
+			</form>
+
+			<hr />
+
+			<h2>Retention</h2>
+
+			<?php if ( null !== $retention_result ) : ?>
+			<div class="notice notice-success inline">
+				<p>Retention job completed: <strong><?php echo esc_html( (string) $retention_result ); ?></strong> record(s) anonymized.</p>
+			</div>
+			<?php endif; ?>
+
+			<?php if ( is_array( $last_run ) ) : ?>
+			<p>
+				Last run: <strong><?php echo esc_html( $last_run['timestamp'] ?? '—' ); ?></strong>
+				&mdash; <?php echo esc_html( (string) ( $last_run['count'] ?? 0 ) ); ?> record(s) anonymized.
+			</p>
+			<?php else : ?>
+			<p>The retention job has not run yet.</p>
+			<?php endif; ?>
+
+			<p>
+				The retention job also runs automatically once per day via WP-Cron.
+				On production, back it up with a server cron:
+				<code>wp cron event run --due-now</code>
+			</p>
+
+			<form method="post">
+				<?php wp_nonce_field( self::NONCE_ACTION_RUN_NOW, self::NONCE_FIELD_RUN_NOW ); ?>
+				<?php submit_button( 'Run retention now', 'secondary' ); ?>
 			</form>
 		</div>
 		<?php

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -62,18 +62,21 @@ class Settings_Page {
 	}
 
 	/**
-	 * Run the retention job immediately and redirect back with a status param.
+	 * Handle the run-now POST on admin_init — fires before any output so
+	 * wp_safe_redirect() can send the Location header cleanly.
+	 *
+	 * Hooked in download-gateway.php via add_action( 'admin_init', ... ).
 	 */
-	private static function handle_run_now(): void {
-		if (
-			! isset( $_POST[ self::NONCE_FIELD_RUN_NOW ] ) ||
-			! wp_verify_nonce( sanitize_key( $_POST[ self::NONCE_FIELD_RUN_NOW ] ), self::NONCE_ACTION_RUN_NOW )
-		) {
+	public static function handle_run_now_action(): void {
+		if ( ! isset( $_POST[ self::NONCE_FIELD_RUN_NOW ] ) ) {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return;
+		if (
+			! wp_verify_nonce( sanitize_key( $_POST[ self::NONCE_FIELD_RUN_NOW ] ), self::NONCE_ACTION_RUN_NOW )
+			|| ! current_user_can( 'manage_options' )
+		) {
+			wp_die( 'Unauthorized.', 403 );
 		}
 
 		$count = RetentionJob::anonymize();
@@ -93,11 +96,6 @@ class Settings_Page {
 	public static function render(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
-		}
-
-		// Handle run-now before any output — it redirects on success.
-		if ( isset( $_POST[ self::NONCE_FIELD_RUN_NOW ] ) ) {
-			self::handle_run_now();
 		}
 
 		// Handle settings form submission.

--- a/wp-content/plugins/download-gateway/includes/class-acf-fields.php
+++ b/wp-content/plugins/download-gateway/includes/class-acf-fields.php
@@ -27,7 +27,13 @@ class Acf_Fields {
 		}
 
 		$location = array_map(
-			fn( string $pt ) => array( array( 'param' => 'post_type', 'operator' => '==', 'value' => $pt ) ),
+			fn( string $pt ) => array(
+				array(
+					'param'    => 'post_type',
+					'operator' => '==',
+					'value'    => $pt,
+				),
+			),
 			$post_types
 		);
 

--- a/wp-content/plugins/download-gateway/includes/class-activator.php
+++ b/wp-content/plugins/download-gateway/includes/class-activator.php
@@ -16,15 +16,17 @@ class Activator {
 		self::check_requirements();
 		update_option( 'gateway_version', GATEWAY_VERSION );
 		Schema::create_tables();
+		RetentionJob::schedule();
 		Logger::info( 'Plugin activated (v' . GATEWAY_VERSION . ').' );
 	}
 
 	public static function deactivate(): void {
+		RetentionJob::unschedule();
 		Logger::info( 'Plugin deactivated.' );
 	}
 
 	private static function check_requirements(): void {
-		$errors = [];
+		$errors = array();
 
 		if ( version_compare( PHP_VERSION, '8.2', '<' ) ) {
 			$errors[] = 'Download Gateway requires PHP 8.2 or higher. Current version: ' . PHP_VERSION;
@@ -42,7 +44,7 @@ class Activator {
 				. implode( '</li><li>', array_map( 'esc_html', $errors ) )
 				. '</li></ul>',
 				'Plugin Activation Error',
-				[ 'back_link' => true ]
+				array( 'back_link' => true )
 			);
 		}
 	}

--- a/wp-content/plugins/download-gateway/includes/class-download-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-controller.php
@@ -24,21 +24,21 @@ class DownloadController {
 		register_rest_route(
 			GATEWAY_REST_NAMESPACE,
 			'/download/(?P<id>[a-zA-Z0-9]+)',
-			[
+			array(
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'handle' ],
+				'callback'            => array( $this, 'handle' ),
 				'permission_callback' => '__return_true',
-				'args'                => [
-					'id'     => [
+				'args'                => array(
+					'id'     => array(
 						'required'          => true,
 						'validate_callback' => fn( $v ) => is_string( $v ) && strlen( $v ) > 0,
-					],
-					'format' => [
+					),
+					'format' => array(
 						'required'          => false,
-						'validate_callback' => fn( $v ) => in_array( $v, [ 'json' ], true ),
-					],
-				],
-			]
+						'validate_callback' => fn( $v ) => in_array( $v, array( 'json' ), true ),
+					),
+				),
+			)
 		);
 	}
 
@@ -68,7 +68,7 @@ class DownloadController {
 		VisitorId::set_cookie( $visitor_id );
 
 		if ( 'json' === $format ) {
-			return new \WP_REST_Response( [ 'url' => $result ], 200 );
+			return new \WP_REST_Response( array( 'url' => $result ), 200 );
 		}
 
 		header( 'Cache-Control: no-store, no-cache, must-revalidate' );
@@ -88,7 +88,7 @@ class DownloadController {
 	 * @param array  $server  Server array (typically $_SERVER).
 	 * @return string|\WP_Error File URL on success, WP_Error on failure.
 	 */
-	public function resolve( string $id, array $cookies = [], array $server = [] ): string|\WP_Error {
+	public function resolve( string $id, array $cookies = array(), array $server = array() ): string|\WP_Error {
 		if ( ctype_digit( $id ) ) {
 			return $this->resolve_post_id( (int) $id, $cookies, $server );
 		}
@@ -97,7 +97,7 @@ class DownloadController {
 			return $this->resolve_token( $id, $cookies, $server );
 		}
 
-		return new \WP_Error( 'invalid_id', 'Invalid download ID.', [ 'status' => 400 ] );
+		return new \WP_Error( 'invalid_id', 'Invalid download ID.', array( 'status' => 400 ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -107,12 +107,12 @@ class DownloadController {
 	private function resolve_post_id( int $post_id, array $cookies, array $server ): string|\WP_Error {
 		$resolver = FileResolverRegistry::for_post( $post_id );
 		if ( null === $resolver ) {
-			return new \WP_Error( 'not_found', 'No file resolver for this resource.', [ 'status' => 404 ] );
+			return new \WP_Error( 'not_found', 'No file resolver for this resource.', array( 'status' => 404 ) );
 		}
 
 		$policy = PolicyResolver::resolve( $post_id );
 		if ( SettingsRepository::POLICY_HARD === $policy ) {
-			return new \WP_Error( 'gate_required', 'Email address required to download this resource.', [ 'status' => 403 ] );
+			return new \WP_Error( 'gate_required', 'Email address required to download this resource.', array( 'status' => 403 ) );
 		}
 
 		$visitor_id = VisitorId::from_cookies( $cookies ) ?? VisitorId::generate();
@@ -120,16 +120,24 @@ class DownloadController {
 		$ip_hash    = IpHasher::hash_from_server( $server );
 		$post_type  = get_post_type( $post_id );
 
-		DownloadEventRepository::log( [
-			'post_id'      => $post_id,
-			'post_type'    => $post_type,
-			'event_type'   => DownloadEventRepository::EVENT_CLICK,
-			'visitor_id'   => $visitor_id,
-			'storage_type' => $resolver->storage_type(),
-			'ip_hash'      => $ip_hash,
-		] );
+		DownloadEventRepository::log(
+			array(
+				'post_id'      => $post_id,
+				'post_type'    => $post_type,
+				'event_type'   => DownloadEventRepository::EVENT_CLICK,
+				'visitor_id'   => $visitor_id,
+				'storage_type' => $resolver->storage_type(),
+				'ip_hash'      => $ip_hash,
+			)
+		);
 
-		EventBus::dispatch( 'download/click', [ 'post_id' => $post_id, 'visitor_id' => $visitor_id ] );
+		EventBus::dispatch(
+			'download/click',
+			array(
+				'post_id'    => $post_id,
+				'visitor_id' => $visitor_id,
+			)
+		);
 
 		return $this->get_file_url( $post_id, $resolver, $visitor_id, $token_str, $server );
 	}
@@ -137,18 +145,18 @@ class DownloadController {
 	private function resolve_token( string $token, array $cookies, array $server ): string|\WP_Error {
 		$row = TokenRepository::find_by_token( $token );
 		if ( null === $row ) {
-			return new \WP_Error( 'token_invalid', 'Token not found.', [ 'status' => 410 ] );
+			return new \WP_Error( 'token_invalid', 'Token not found.', array( 'status' => 410 ) );
 		}
 
 		if ( ! TokenRepository::is_valid( $row ) ) {
-			return new \WP_Error( 'token_expired', 'Token has expired or already been used.', [ 'status' => 410 ] );
+			return new \WP_Error( 'token_expired', 'Token has expired or already been used.', array( 'status' => 410 ) );
 		}
 
 		TokenRepository::mark_used( $token );
 
 		$resolver = FileResolverRegistry::for_post( (int) $row->post_id );
 		if ( null === $resolver ) {
-			return new \WP_Error( 'not_found', 'No file resolver for this resource.', [ 'status' => 404 ] );
+			return new \WP_Error( 'not_found', 'No file resolver for this resource.', array( 'status' => 404 ) );
 		}
 
 		$visitor_id = $row->visitor_id ?? VisitorId::from_cookies( $cookies );
@@ -166,19 +174,27 @@ class DownloadController {
 		$url = $resolver->resolve( $post_id );
 		if ( null === $url ) {
 			Logger::error( "DownloadController: resolver returned null for post {$post_id}." );
-			return new \WP_Error( 'file_not_found', 'File could not be resolved.', [ 'status' => 404 ] );
+			return new \WP_Error( 'file_not_found', 'File could not be resolved.', array( 'status' => 404 ) );
 		}
 
-		DownloadEventRepository::log( [
-			'post_id'      => $post_id,
-			'post_type'    => get_post_type( $post_id ),
-			'event_type'   => DownloadEventRepository::EVENT_REDIRECT,
-			'visitor_id'   => $visitor_id,
-			'storage_type' => $resolver->storage_type(),
-			'ip_hash'      => IpHasher::hash_from_server( $server ),
-		] );
+		DownloadEventRepository::log(
+			array(
+				'post_id'      => $post_id,
+				'post_type'    => get_post_type( $post_id ),
+				'event_type'   => DownloadEventRepository::EVENT_REDIRECT,
+				'visitor_id'   => $visitor_id,
+				'storage_type' => $resolver->storage_type(),
+				'ip_hash'      => IpHasher::hash_from_server( $server ),
+			)
+		);
 
-		EventBus::dispatch( 'download/redirect', [ 'post_id' => $post_id, 'url' => $url ] );
+		EventBus::dispatch(
+			'download/redirect',
+			array(
+				'post_id' => $post_id,
+				'url'     => $url,
+			)
+		);
 
 		return $url;
 	}

--- a/wp-content/plugins/download-gateway/includes/class-download-event-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-event-repository.php
@@ -25,10 +25,10 @@ namespace WT\DownloadGateway;
 class DownloadEventRepository {
 
 	// Valid event_type values — mirrors the schema comment in class-schema.php.
-	const EVENT_CLICK        = 'click';
-	const EVENT_GATE_VIEW    = 'gate_view';
-	const EVENT_GATE_SUBMIT  = 'gate_submit';
-	const EVENT_REDIRECT     = 'redirect';
+	const EVENT_CLICK       = 'click';
+	const EVENT_GATE_VIEW   = 'gate_view';
+	const EVENT_GATE_SUBMIT = 'gate_submit';
+	const EVENT_REDIRECT    = 'redirect';
 
 	/**
 	 * Insert a download event row.
@@ -58,22 +58,22 @@ class DownloadEventRepository {
 			return false;
 		}
 
-		$row = [
+		$row = array(
 			'post_id'      => (int) $data['post_id'],
 			'post_type'    => sanitize_key( $data['post_type'] ),
 			'event_type'   => sanitize_key( $data['event_type'] ),
-			'visitor_id'   => isset( $data['visitor_id'] )   ? sanitize_text_field( $data['visitor_id'] )   : null,
-			'person_id'    => isset( $data['person_id'] )    ? (int) $data['person_id']                     : null,
-			'storage_type' => isset( $data['storage_type'] ) ? sanitize_key( $data['storage_type'] )        : null,
-			'ip_hash'      => isset( $data['ip_hash'] )      ? sanitize_text_field( $data['ip_hash'] )      : null,
-			'utm_source'   => isset( $data['utm_source'] )   ? sanitize_text_field( $data['utm_source'] )   : null,
-			'utm_medium'   => isset( $data['utm_medium'] )   ? sanitize_text_field( $data['utm_medium'] )   : null,
+			'visitor_id'   => isset( $data['visitor_id'] ) ? sanitize_text_field( $data['visitor_id'] ) : null,
+			'person_id'    => isset( $data['person_id'] ) ? (int) $data['person_id'] : null,
+			'storage_type' => isset( $data['storage_type'] ) ? sanitize_key( $data['storage_type'] ) : null,
+			'ip_hash'      => isset( $data['ip_hash'] ) ? sanitize_text_field( $data['ip_hash'] ) : null,
+			'utm_source'   => isset( $data['utm_source'] ) ? sanitize_text_field( $data['utm_source'] ) : null,
+			'utm_medium'   => isset( $data['utm_medium'] ) ? sanitize_text_field( $data['utm_medium'] ) : null,
 			'utm_campaign' => isset( $data['utm_campaign'] ) ? sanitize_text_field( $data['utm_campaign'] ) : null,
-			'utm_term'     => isset( $data['utm_term'] )     ? sanitize_text_field( $data['utm_term'] )     : null,
-			'utm_content'  => isset( $data['utm_content'] )  ? sanitize_text_field( $data['utm_content'] )  : null,
-			'referrer'     => isset( $data['referrer'] )     ? esc_url_raw( $data['referrer'] )             : null,
+			'utm_term'     => isset( $data['utm_term'] ) ? sanitize_text_field( $data['utm_term'] ) : null,
+			'utm_content'  => isset( $data['utm_content'] ) ? sanitize_text_field( $data['utm_content'] ) : null,
+			'referrer'     => isset( $data['referrer'] ) ? esc_url_raw( $data['referrer'] ) : null,
 			'created_at'   => current_time( 'mysql' ),
-		];
+		);
 
 		$result = $wpdb->insert( $wpdb->prefix . 'gateway_download_events', $row );
 

--- a/wp-content/plugins/download-gateway/includes/class-event-bus.php
+++ b/wp-content/plugins/download-gateway/includes/class-event-bus.php
@@ -33,7 +33,7 @@ class EventBus {
 	 * @param string $event   Short event name, e.g. 'download/click'.
 	 * @param array  $payload Arbitrary data passed to listeners.
 	 */
-	public static function dispatch( string $event, array $payload = [] ): void {
+	public static function dispatch( string $event, array $payload = array() ): void {
 		do_action( self::HOOK_PREFIX . $event, $payload );
 	}
 

--- a/wp-content/plugins/download-gateway/includes/class-file-resolver-registry.php
+++ b/wp-content/plugins/download-gateway/includes/class-file-resolver-registry.php
@@ -22,7 +22,7 @@ namespace WT\DownloadGateway;
 class FileResolverRegistry {
 
 	/** @var array<string, FileResolver> post_type → resolver map */
-	private static array $resolvers = [];
+	private static array $resolvers = array();
 
 	/**
 	 * Register a resolver for a post type.
@@ -82,6 +82,6 @@ class FileResolverRegistry {
 	 * For use in tests only — allows each test to start from a clean registry.
 	 */
 	public static function reset(): void {
-		self::$resolvers = [];
+		self::$resolvers = array();
 	}
 }

--- a/wp-content/plugins/download-gateway/includes/class-gate-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-gate-controller.php
@@ -30,11 +30,11 @@ class GateController {
 		register_rest_route(
 			GATEWAY_REST_NAMESPACE,
 			'/gate',
-			[
+			array(
 				'methods'             => 'POST',
-				'callback'            => [ $this, 'handle' ],
+				'callback'            => array( $this, 'handle' ),
 				'permission_callback' => '__return_true',
-			]
+			)
 		);
 	}
 
@@ -88,24 +88,24 @@ class GateController {
 		bool $consent_download,
 		string $nonce,
 		string $honeypot,
-		array $cookies = [],
-		array $server = [],
+		array $cookies = array(),
+		array $server = array(),
 		string $passthrough = ''
 	): array|\WP_Error {
 
 		// Honeypot — bots fill hidden fields; silently succeed.
 		if ( '' !== $honeypot ) {
-			return [ 'token' => null ];
+			return array( 'token' => null );
 		}
 
 		// Nonce verification.
 		if ( ! wp_verify_nonce( $nonce, 'gateway_gate' ) ) {
-			return new \WP_Error( 'invalid_nonce', 'Request could not be verified.', [ 'status' => 403 ] );
+			return new \WP_Error( 'invalid_nonce', 'Request could not be verified.', array( 'status' => 403 ) );
 		}
 
 		// Field validation.
 		if ( $post_id <= 0 ) {
-			return new \WP_Error( 'invalid_post_id', 'Invalid resource.', [ 'status' => 400 ] );
+			return new \WP_Error( 'invalid_post_id', 'Invalid resource.', array( 'status' => 400 ) );
 		}
 
 		// Passthrough — returning visitor with gateway_gated cookie skips the form.
@@ -119,29 +119,32 @@ class GateController {
 		$rate_key = 'gw_rate_' . substr( $ip_hash, 0, 28 );
 		$count    = (int) get_transient( $rate_key );
 		if ( $count >= self::RATE_LIMIT ) {
-			return new \WP_Error( 'rate_limited', 'Too many requests. Please try again later.', [ 'status' => 429 ] );
+			return new \WP_Error( 'rate_limited', 'Too many requests. Please try again later.', array( 'status' => 429 ) );
 		}
 		set_transient( $rate_key, $count + 1, self::RATE_WINDOW );
 
 		if ( ! is_email( $email ) ) {
-			return new \WP_Error( 'invalid_email', 'A valid email address is required.', [ 'status' => 400 ] );
+			return new \WP_Error( 'invalid_email', 'A valid email address is required.', array( 'status' => 400 ) );
 		}
 		$name = trim( $name );
 		if ( '' === $name ) {
-			return new \WP_Error( 'invalid_name', 'Your name is required.', [ 'status' => 400 ] );
+			return new \WP_Error( 'invalid_name', 'Your name is required.', array( 'status' => 400 ) );
 		}
 
 		// Upsert person.
 		$person_id = PeopleRepository::upsert( $email, $name, $consent_download );
 		if ( false === $person_id ) {
-			return new \WP_Error( 'db_error', 'Could not save your information. Please try again.', [ 'status' => 500 ] );
+			return new \WP_Error( 'db_error', 'Could not save your information. Please try again.', array( 'status' => 500 ) );
 		}
 
 		// Create one-time download token tied to this person.
 		$visitor_id = VisitorId::from_cookies( $cookies );
 		$token      = TokenRepository::create( $post_id, TokenRepository::TTL_DEFAULT, $visitor_id, $person_id );
 
-		return [ 'token' => $token, 'person_id' => $person_id ];
+		return array(
+			'token'     => $token,
+			'person_id' => $person_id,
+		);
 	}
 
 	/**
@@ -160,18 +163,21 @@ class GateController {
 		$person_id = (int) $passthrough;
 
 		if ( $person_id <= 0 ) {
-			return new \WP_Error( 'invalid_passthrough', 'Invalid session.', [ 'status' => 400 ] );
+			return new \WP_Error( 'invalid_passthrough', 'Invalid session.', array( 'status' => 400 ) );
 		}
 
 		$person = PeopleRepository::find_by_id( $person_id );
 		if ( null === $person ) {
 			// Person was anonymized or never existed — JS will show the gate form.
-			return new \WP_Error( 'passthrough_expired', 'Session expired. Please complete the form.', [ 'status' => 410 ] );
+			return new \WP_Error( 'passthrough_expired', 'Session expired. Please complete the form.', array( 'status' => 410 ) );
 		}
 
 		$visitor_id = VisitorId::from_cookies( $cookies );
 		$token      = TokenRepository::create( $post_id, TokenRepository::TTL_DEFAULT, $visitor_id, (int) $person->id );
 
-		return [ 'token' => $token, 'person_id' => (int) $person->id ];
+		return array(
+			'token'     => $token,
+			'person_id' => (int) $person->id,
+		);
 	}
 }

--- a/wp-content/plugins/download-gateway/includes/class-people-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-people-repository.php
@@ -41,6 +41,7 @@ class PeopleRepository {
 
 		$existing_id = $wpdb->get_var(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"SELECT id FROM {$table} WHERE email_hash = %s AND is_anonymized = 0",
 				$email_hash
 			)
@@ -49,27 +50,27 @@ class PeopleRepository {
 		if ( null !== $existing_id ) {
 			$wpdb->update(
 				$table,
-				[
-					'name'               => sanitize_text_field( $name ),
-					'consent_download'   => $consent_download ? 1 : 0,
-					'consent_marketing'  => $consent_marketing ? 1 : 0,
-				],
-				[ 'id' => (int) $existing_id ]
+				array(
+					'name'              => sanitize_text_field( $name ),
+					'consent_download'  => $consent_download ? 1 : 0,
+					'consent_marketing' => $consent_marketing ? 1 : 0,
+				),
+				array( 'id' => (int) $existing_id )
 			);
 			return (int) $existing_id;
 		}
 
 		$result = $wpdb->insert(
 			$table,
-			[
-				'email_hash'         => $email_hash,
-				'email'              => sanitize_email( $email ),
-				'name'               => sanitize_text_field( $name ),
-				'consent_download'   => $consent_download ? 1 : 0,
-				'consent_marketing'  => $consent_marketing ? 1 : 0,
-				'is_anonymized'      => 0,
-				'created_at'         => current_time( 'mysql' ),
-			]
+			array(
+				'email_hash'        => $email_hash,
+				'email'             => sanitize_email( $email ),
+				'name'              => sanitize_text_field( $name ),
+				'consent_download'  => $consent_download ? 1 : 0,
+				'consent_marketing' => $consent_marketing ? 1 : 0,
+				'is_anonymized'     => 0,
+				'created_at'        => current_time( 'mysql' ),
+			)
 		);
 
 		if ( false === $result ) {
@@ -95,6 +96,7 @@ class PeopleRepository {
 
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"SELECT * FROM {$table} WHERE id = %d AND is_anonymized = 0",
 				$person_id
 			)
@@ -117,6 +119,7 @@ class PeopleRepository {
 
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"SELECT * FROM {$table} WHERE email_hash = %s AND is_anonymized = 0",
 				$email_hash
 			)

--- a/wp-content/plugins/download-gateway/includes/class-policy-resolver.php
+++ b/wp-content/plugins/download-gateway/includes/class-policy-resolver.php
@@ -101,7 +101,7 @@ class PolicyResolver {
 	 * @param mixed $value Raw value from postmeta or term meta.
 	 */
 	private static function validate_policy( mixed $value ): ?string {
-		$valid = [ SettingsRepository::POLICY_NONE, SettingsRepository::POLICY_SOFT, SettingsRepository::POLICY_HARD ];
+		$valid = array( SettingsRepository::POLICY_NONE, SettingsRepository::POLICY_SOFT, SettingsRepository::POLICY_HARD );
 		return ( is_string( $value ) && in_array( $value, $valid, true ) ) ? $value : null;
 	}
 }

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -25,7 +25,7 @@ class Resource_Metabox {
 		add_meta_box(
 			'gateway_resource',
 			'Download Gateway',
-			[ self::class, 'render' ],
+			array( self::class, 'render' ),
 			$post_types,
 			'side',
 			'default'
@@ -48,7 +48,7 @@ class Resource_Metabox {
 			return;
 		}
 
-		$allowed = [ '', 'none', 'soft', 'hard' ];
+		$allowed = array( '', 'none', 'soft', 'hard' );
 		$value   = isset( $_POST['_gateway_gate_policy'] )
 			? sanitize_key( $_POST['_gateway_gate_policy'] )
 			: '';

--- a/wp-content/plugins/download-gateway/includes/class-retention-job.php
+++ b/wp-content/plugins/download-gateway/includes/class-retention-job.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * RetentionJob — anonymizes stale person records on a daily schedule.
+ *
+ * People who submitted the gate form have their email and name nulled out
+ * after `retention_months` (default: 24). The row is kept so that download
+ * event records (which reference person_id) remain intact for reporting.
+ * The `is_anonymized` flag prevents re-upsert from resurrecting a deleted
+ * identity — re-capture after anonymization creates a fresh row.
+ *
+ * WP Cron fires only on page visits. Production environments should back
+ * this up with a server cron: `wp cron event run --due-now`
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class RetentionJob {
+
+	/** WP-Cron hook name. */
+	const CRON_HOOK = 'gateway_retention_daily';
+
+	/** Option key for last-run metadata. */
+	const OPTION_LAST_RUN = 'gateway_retention_last_run';
+
+	/**
+	 * Anonymize person records older than the configured retention window.
+	 *
+	 * Nulls `email` and `name`, sets `is_anonymized = 1` and `anonymized_at`
+	 * for all non-anonymized records whose `created_at` falls before the
+	 * retention cutoff. Returns the number of records anonymized.
+	 *
+	 * @return int Number of records anonymized.
+	 */
+	public static function anonymize(): int {
+		global $wpdb;
+
+		$table            = $wpdb->prefix . 'gateway_people';
+		$retention_months = SettingsRepository::get_retention_months();
+		$now              = current_time( 'mysql' );
+
+		$sql = $wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"UPDATE {$table}
+			 SET email = NULL, name = NULL, is_anonymized = 1, anonymized_at = %s
+			 WHERE is_anonymized = 0
+			   AND created_at < DATE_SUB( %s, INTERVAL %d MONTH )",
+			$now,
+			$now,
+			$retention_months
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query( $sql );
+		$count  = false !== $result ? (int) $result : 0;
+
+		update_option(
+			self::OPTION_LAST_RUN,
+			array(
+				'timestamp' => $now,
+				'count'     => $count,
+			)
+		);
+
+		Logger::info( "Retention: anonymized {$count} record(s) older than {$retention_months} months." );
+
+		return $count;
+	}
+
+	/**
+	 * Schedule the daily retention cron event if not already scheduled.
+	 */
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Unschedule the daily retention cron event.
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-schema.php
+++ b/wp-content/plugins/download-gateway/includes/class-schema.php
@@ -157,12 +157,12 @@ class Schema {
 		global $wpdb;
 
 		// Drop in reverse dependency order (events reference people; tokens reference both).
-		$tables = [
+		$tables = array(
 			"{$wpdb->prefix}gateway_webhook_delivery",
 			"{$wpdb->prefix}gateway_download_events",
 			"{$wpdb->prefix}gateway_tokens",
 			"{$wpdb->prefix}gateway_people",
-		];
+		);
 
 		foreach ( $tables as $table ) {
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/wp-content/plugins/download-gateway/includes/class-settings-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-settings-repository.php
@@ -35,7 +35,7 @@ class SettingsRepository {
 	 */
 	public static function get_global_gate_policy(): string {
 		$value = get_option( self::OPTION_GLOBAL_GATE_POLICY, self::DEFAULT_GLOBAL_GATE_POLICY );
-		return in_array( $value, [ self::POLICY_NONE, self::POLICY_SOFT, self::POLICY_HARD ], true )
+		return in_array( $value, array( self::POLICY_NONE, self::POLICY_SOFT, self::POLICY_HARD ), true )
 			? $value
 			: self::DEFAULT_GLOBAL_GATE_POLICY;
 	}

--- a/wp-content/plugins/download-gateway/includes/class-token-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-token-repository.php
@@ -36,14 +36,14 @@ class TokenRepository {
 
 		$wpdb->insert(
 			$wpdb->prefix . 'gateway_tokens',
-			[
+			array(
 				'token'      => $token,
 				'post_id'    => $post_id,
 				'visitor_id' => $visitor_id,
 				'person_id'  => $person_id,
 				'expires_at' => gmdate( 'Y-m-d H:i:s', time() + $ttl_seconds ),
 				'created_at' => current_time( 'mysql' ),
-			]
+			)
 		);
 
 		Logger::debug( "Token created for post_id={$post_id}." );
@@ -62,6 +62,7 @@ class TokenRepository {
 
 		$table = $wpdb->prefix . 'gateway_tokens';
 		$row   = $wpdb->get_row(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$wpdb->prepare( "SELECT * FROM {$table} WHERE token = %s", $token )
 		);
 
@@ -79,8 +80,8 @@ class TokenRepository {
 
 		$result = $wpdb->update(
 			$wpdb->prefix . 'gateway_tokens',
-			[ 'used_at' => current_time( 'mysql' ) ],
-			[ 'token'   => $token ]
+			array( 'used_at' => current_time( 'mysql' ) ),
+			array( 'token' => $token )
 		);
 
 		return false !== $result;
@@ -118,6 +119,7 @@ class TokenRepository {
 		$table  = $wpdb->prefix . 'gateway_tokens';
 		$result = $wpdb->query(
 			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				"DELETE FROM {$table} WHERE expires_at < %s AND used_at IS NULL",
 				current_time( 'mysql' )
 			)

--- a/wp-content/plugins/download-gateway/includes/class-visitor-id.php
+++ b/wp-content/plugins/download-gateway/includes/class-visitor-id.php
@@ -63,13 +63,13 @@ class VisitorId {
 		setcookie(
 			self::COOKIE_NAME,
 			$visitor_id,
-			[
+			array(
 				'expires'  => time() + self::COOKIE_TTL,
 				'path'     => '/',
 				'secure'   => is_ssl(),
 				'httponly' => true,
 				'samesite' => 'Lax',
-			]
+			)
 		);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `RetentionJob` class: daily WP-Cron job that nulls `email`/`name` and sets `is_anonymized = 1` on `wp_gateway_people` records older than the configured retention window (default: 24 months). Rows are kept intact so download event history remains queryable.
- `Activator` schedules the cron on plugin activation and unschedules on deactivation.
- Settings page gains a **Data retention** field (months), a last-run info block, and a **Run retention now** button for manual execution.
- Adds `wp-content/plugins/download-gateway` to `phpcs.xml` scan scope — plugin code is now linted on every PR. phpcbf auto-fixed 101 short-array violations (`[]` → `array()`) across all plugin files; `{$table}` interpolation in `wpdb->prepare()` calls suppressed with targeted `phpcs:ignore` comments.
- 3 new unit tests (144 total, 212 assertions). PHPStan clean.

## Test plan

- [ ] Activate plugin on localhost — confirm `gateway_retention_daily` cron event is scheduled (`wp cron event list`)
- [ ] Set retention to 0 months, click **Run retention now** — confirm no records anonymized (validation clamps to default 24)
- [ ] Set retention months and save — confirm value persists
- [ ] Insert a test person with old `created_at`, click **Run retention now** — confirm email/name nulled, `is_anonymized = 1`, `anonymized_at` set, count shown in success notice
- [ ] Deactivate plugin — confirm `gateway_retention_daily` removed from cron list

🤖 Generated with [Claude Code](https://claude.com/claude-code)