### PR TITLE
feat: gateway sub-phase 5b-i — policy model expansion

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -237,17 +237,23 @@ Downloads currently go through unprotected direct file URLs or `force_download_f
 - [x] **3** — Download endpoint: `GET /wp-json/gateway/v1/download/{token-or-post-id}`, `gateway_vid` visitor cookie, click + redirect event logging, IP hashing, no-cache headers. Tested on localhost — 302 redirect confirmed (PR #560)
 - [x] **4** — Resource authoring: native WP metabox (gate policy select + file URL + shortcode snippet), `[gateway_download]` shortcode. All three validated on localhost. (PR #561)
 - [x] **5** — Gate modes: soft (skippable modal) and hard (email required); `POST /wp-json/gateway/v1/gate`; PeopleRepository upsert; one-time token; nonce + rate limit + honeypot; silent passthrough via `gateway_gated` cookie. All policy permutations validated on localhost. (PR #561)
-- **5b** — Policy model expansion + intake form infrastructure:
-  - Extend `PolicyResolver` to 3-tier resolution (add per-CPT tier); add `disabled` as a policy value
-  - `SettingsRepository::get_cpt_policy()` + `update_cpt_policy()`
-  - Settings page: per-CPT policy rows (populated from `FileResolverRegistry::registered_post_types()`); admin table listing all posts with non-`inherit` policy overrides (post title, post type, current override value) for at-a-glance audit
-  - `Download_Shortcode`: suppress output when policy resolves to `disabled`
-  - `gateway_intake_fields` PHP filter; multi-step modal JS (step 2 rendered from `gatewaySettings.intakeSteps[postType]`)
-  - `wp_gateway_intake_responses` table; `POST /gateway/v1/intake` endpoint; `GateController` accepts + forwards `intake` payload
+- **5b-i** — Policy model expansion _(in progress)_:
+  - Replace taxonomy tier with per-CPT tier in `PolicyResolver`; add `disabled` as a policy value (hides download affordance entirely)
+  - `SettingsRepository::get_cpt_policy()` + `update_cpt_policy()`; `concrete_policies()` + `allowed_override_values()` helpers
+  - `gateway_policy_post_types` filter — defaults to `FileResolverRegistry::registered_post_types()`; videos + captions added via filter until their FileResolvers land in sub-phase 6 (remove filter entries at that point)
+  - Settings page: per-CPT policy rows; admin audit table of all posts with non-inherit per-resource overrides
+  - `Download_Shortcode`: return empty string when policy resolves to `disabled`
+  - `Resource_Metabox`: add `disabled` option; update inherit label to "Inherit (use CPT / global default)"
+- **5b-ii** — Intake form infrastructure:
+  - `wp_gateway_intake_responses` table; bump schema version
+  - `gateway_intake_fields` PHP filter; fields registered in theme/CPT code; gateway plugin is field-agnostic
+  - `IntakeController`: `POST /gateway/v1/intake`; stores response blob per person+post
+  - `wp_localize_script`: add `intakeSteps[postType]` payload
+  - Multi-step modal JS: step 2 rendered from `gatewaySettings.intakeSteps[postType]` (only shown when fields are defined for the CPT)
 - **6** — Storage adapters + Dropbox: local/media/external adapters; Dropbox adapter calls `files/get_temporary_link`, caches briefly, stores credentials in `wp_options` with `autoload=no`
 - **7** — GA4 forwarding: EventBus subscriber; client-side where possible; events: `resource_download_click`, `resource_download_gate_submit`, `resource_download_redirect`
 - **8** — Admin reporting: date-filtered download table, top resources, CSV export with capability check
-- **9** — Retention automation: daily cron nulls email/name after `retention_months`, marks `is_anonymized`; manual run-now button
+- [x] **9** — Retention automation: daily cron nulls email/name after `retention_months`, marks `is_anonymized`; manual run-now button. (PR #565)
 - **10** — Rollout: convert resources hub first, then top downloads; deprecate `document-download-handler.php` `force_download_file()` once coverage is complete
 
 **Implementation notes:**
@@ -339,7 +345,7 @@ Three known divergence directions:
 - **6** — Storage adapters + Dropbox: local/media/external adapters; Dropbox adapter calls `files/get_temporary_link`, caches briefly, stores credentials in `wp_options` with `autoload=no`
 - **7** — GA4 forwarding: EventBus subscriber; client-side where possible; events: `resource_download_click`, `resource_download_gate_submit`, `resource_download_redirect`
 - **8** — Admin reporting: date-filtered download table, top resources, CSV export with capability check
-- **9** — Retention automation: daily cron nulls email/name after `retention_months`, marks `is_anonymized`; manual run-now button
+- [x] **9** — Retention automation: daily cron nulls email/name after `retention_months`, marks `is_anonymized`; manual run-now button. (PR #565)
 - **10** — Rollout: convert resources hub first, then top downloads; deprecate `document-download-handler.php` `force_download_file()` once coverage is complete
 
 ---

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -128,6 +128,19 @@ add_action(
 // Register file resolvers for supported post types.
 FileResolverRegistry::register( 'document_files', new DocumentFileResolver() );
 
+/*
+ * Expose videos and captions in per-CPT policy settings before their
+ * FileResolvers are built (sub-phase 6 — Dropbox adapter).
+ * Remove these entries once VideoFileResolver and CaptionFileResolver
+ * are registered above — they will appear automatically at that point.
+ */
+add_filter(
+	'gateway_policy_post_types',
+	function ( array $types ): array {
+		return array_unique( array_merge( $types, array( 'videos', 'captions' ) ) );
+	}
+);
+
 add_action(
 	RetentionJob::CRON_HOOK,
 	function (): void {

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -2,8 +2,12 @@
 /**
  * Settings_Page — admin UI for the download gateway.
  *
- * Settings → Download Gateway. Exposes the global gate policy, the data
- * retention window, and a manual run-now button for the retention job.
+ * Settings → Download Gateway. Exposes:
+ *   - Global gate policy (site-wide fallback)
+ *   - Per-CPT gate policy (one row per registered post type)
+ *   - Data retention window
+ *   - Manual run-now button for the retention job
+ *   - Audit table of all per-resource policy overrides
  *
  * @package WT\DownloadGateway
  */
@@ -39,17 +43,27 @@ class Settings_Page {
 			return;
 		}
 
-		$allowed = array( 'none', 'soft', 'hard' );
-		$policy  = isset( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
+		// Global gate policy.
+		$global_policy = isset( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
 			? sanitize_key( $_POST[ SettingsRepository::OPTION_GLOBAL_GATE_POLICY ] )
 			: SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
 
-		if ( ! in_array( $policy, $allowed, true ) ) {
-			$policy = SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
+		if ( ! in_array( $global_policy, SettingsRepository::concrete_policies(), true ) ) {
+			$global_policy = SettingsRepository::DEFAULT_GLOBAL_GATE_POLICY;
 		}
 
-		update_option( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $policy );
+		update_option( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $global_policy );
 
+		// Per-CPT policies.
+		/** This filter is documented in Settings_Page::render(). */
+		$post_types = (array) apply_filters( 'gateway_policy_post_types', FileResolverRegistry::registered_post_types() );
+		foreach ( $post_types as $post_type ) {
+			$key   = 'gateway_cpt_policy_' . $post_type;
+			$value = isset( $_POST[ $key ] ) ? sanitize_key( $_POST[ $key ] ) : SettingsRepository::POLICY_INHERIT;
+			SettingsRepository::update_cpt_policy( $post_type, $value );
+		}
+
+		// Data retention.
 		$retention_months = isset( $_POST[ SettingsRepository::OPTION_RETENTION_MONTHS ] )
 			? (int) $_POST[ SettingsRepository::OPTION_RETENTION_MONTHS ]
 			: SettingsRepository::DEFAULT_RETENTION_MONTHS;
@@ -93,6 +107,71 @@ class Settings_Page {
 		exit;
 	}
 
+	/**
+	 * Query wp_postmeta for all posts with a non-empty per-resource policy override.
+	 *
+	 * @return array<int,array{post_id:int,post_title:string,post_type:string,policy:string}>
+	 */
+	private static function get_override_audit_rows(): array {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT pm.post_id, p.post_title, p.post_type, pm.meta_value AS policy
+				 FROM {$wpdb->postmeta} pm
+				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				 WHERE pm.meta_key = %s
+				   AND pm.meta_value != ''
+				   AND pm.meta_value != %s
+				 ORDER BY p.post_type, p.post_title",
+				PolicyResolver::META_KEY,
+				SettingsRepository::POLICY_INHERIT
+			)
+		);
+
+		if ( ! $rows ) {
+			return array();
+		}
+
+		$result = array();
+		foreach ( $rows as $row ) {
+			$result[] = array(
+				'post_id'    => (int) $row->post_id,
+				'post_title' => (string) $row->post_title,
+				'post_type'  => (string) $row->post_type,
+				'policy'     => (string) $row->policy,
+			);
+		}
+		return $result;
+	}
+
+	/** Render a human-readable policy label. */
+	private static function policy_label( string $policy ): string {
+		$labels = array(
+			SettingsRepository::POLICY_NONE     => 'None',
+			SettingsRepository::POLICY_SOFT     => 'Soft gate',
+			SettingsRepository::POLICY_HARD     => 'Hard gate',
+			SettingsRepository::POLICY_DISABLED => 'Disabled',
+			SettingsRepository::POLICY_INHERIT  => 'Inherit',
+		);
+		return $labels[ $policy ] ?? esc_html( $policy );
+	}
+
+	/** Render a <select> for a policy field. */
+	private static function policy_select( string $name, string $current, bool $include_inherit = true ): void {
+		echo '<select name="' . esc_attr( $name ) . '">';
+		if ( $include_inherit ) {
+			echo '<option value="' . esc_attr( SettingsRepository::POLICY_INHERIT ) . '" ' . selected( $current, SettingsRepository::POLICY_INHERIT, false ) . '>Inherit</option>';
+		}
+		echo '<option value="none" ' . selected( $current, 'none', false ) . '>None — direct redirect</option>';
+		echo '<option value="soft" ' . selected( $current, 'soft', false ) . '>Soft gate — skippable prompt</option>';
+		echo '<option value="hard" ' . selected( $current, 'hard', false ) . '>Hard gate — email required</option>';
+		echo '<option value="disabled" ' . selected( $current, 'disabled', false ) . '>Disabled — hide download link</option>';
+		echo '</select>';
+	}
+
 	public static function render(): void {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
@@ -106,6 +185,17 @@ class Settings_Page {
 		$current_policy           = SettingsRepository::get_global_gate_policy();
 		$current_retention_months = SettingsRepository::get_retention_months();
 		$last_run                 = get_option( RetentionJob::OPTION_LAST_RUN, null );
+		/**
+		 * Filters the post types shown in the per-CPT policy settings table.
+		 *
+		 * By default includes all post types with a registered FileResolver.
+		 * Add additional CPTs here before their FileResolver is built so that
+		 * policy can be configured in advance.
+		 *
+		 * @param string[] $post_types Array of post type slugs.
+		 */
+		$post_types = (array) apply_filters( 'gateway_policy_post_types', FileResolverRegistry::registered_post_types() );
+		$audit_rows = self::get_override_audit_rows();
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$retention_result = isset( $_GET['retention_result'] ) ? (int) $_GET['retention_result'] : null;
 		?>
@@ -130,23 +220,31 @@ class Settings_Page {
 			<form method="post">
 				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD ); ?>
 
+				<h2 class="title">Gate policy</h2>
+				<p>
+					Policies resolve in order: per-resource override → per-CPT default → global default.<br />
+					<em>Disabled</em> hides the download link entirely. <em>Inherit</em> falls through to the next tier.
+				</p>
+
 				<table class="form-table" role="presentation">
 					<tr>
-						<th scope="row">
-							<label for="gateway_global_gate_policy">Global gate policy</label>
-						</th>
+						<th scope="row">Global default</th>
 						<td>
-							<select name="<?php echo esc_attr( SettingsRepository::OPTION_GLOBAL_GATE_POLICY ); ?>" id="gateway_global_gate_policy">
-								<option value="none" <?php selected( $current_policy, 'none' ); ?>>None — direct redirect, no gate</option>
-								<option value="soft" <?php selected( $current_policy, 'soft' ); ?>>Soft gate — skippable email prompt</option>
-								<option value="hard" <?php selected( $current_policy, 'hard' ); ?>>Hard gate — email required</option>
-							</select>
-							<p class="description">
-								Site-wide default. Individual resources can override this via the
-								<strong>Download Gateway</strong> metabox in the post editor.
-							</p>
+							<?php self::policy_select( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $current_policy, false ); ?>
+							<p class="description">Site-wide fallback when no per-CPT or per-resource override is set.</p>
 						</td>
 					</tr>
+
+					<?php foreach ( $post_types as $post_type ) : ?>
+						<?php $cpt_policy = SettingsRepository::get_cpt_policy( $post_type ) ?? SettingsRepository::POLICY_INHERIT; ?>
+					<tr>
+						<th scope="row"><?php echo esc_html( $post_type ); ?></th>
+						<td>
+							<?php self::policy_select( 'gateway_cpt_policy_' . $post_type, $cpt_policy ); ?>
+						</td>
+					</tr>
+					<?php endforeach; ?>
+
 					<tr>
 						<th scope="row">
 							<label for="gateway_retention_months">Data retention</label>
@@ -171,6 +269,37 @@ class Settings_Page {
 
 				<?php submit_button( 'Save settings' ); ?>
 			</form>
+
+			<hr />
+
+			<h2>Per-resource overrides</h2>
+
+			<?php if ( empty( $audit_rows ) ) : ?>
+			<p>No per-resource policy overrides are set. All resources use their CPT or global default.</p>
+			<?php else : ?>
+			<table class="widefat striped" style="max-width:700px;">
+				<thead>
+					<tr>
+						<th>Post</th>
+						<th>Type</th>
+						<th>Policy</th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $audit_rows as $row ) : ?>
+					<tr>
+						<td>
+							<a href="<?php echo esc_url( get_edit_post_link( $row['post_id'] ) ); ?>">
+								<?php echo esc_html( $row['post_title'] ?: '(no title)' ); ?>
+							</a>
+						</td>
+						<td><?php echo esc_html( $row['post_type'] ); ?></td>
+						<td><?php echo esc_html( self::policy_label( $row['policy'] ) ); ?></td>
+					</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+			<?php endif; ?>
 
 			<hr />
 

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -38,8 +38,13 @@ class Download_Shortcode {
 			return '<!-- gateway_download: missing or invalid id -->';
 		}
 
-		$url    = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
 		$policy = PolicyResolver::resolve( $post_id );
+
+		if ( SettingsRepository::POLICY_DISABLED === $policy ) {
+			return '';
+		}
+
+		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
 
 		return sprintf(
 			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s">%s</a>',

--- a/wp-content/plugins/download-gateway/includes/class-policy-resolver.php
+++ b/wp-content/plugins/download-gateway/includes/class-policy-resolver.php
@@ -1,21 +1,20 @@
 <?php
 /**
- * PolicyResolver — determines the gate policy for a downloadable post.
+ * PolicyResolver — determines the effective gate policy for a downloadable post.
  *
  * Precedence (highest to lowest):
  *   1. Per-resource postmeta  (_gateway_gate_policy on the post itself)
- *   2. Taxonomy-level default (term meta — wired but inactive until sub-phase 4
- *                              adds ACF fields; resolve() skips this tier if no
- *                              registered taxonomy returns a value)
+ *   2. Per-CPT default        (gateway_cpt_policy_{post_type} option)
  *   3. Global site default    (SettingsRepository::get_global_gate_policy())
  *
- * Return value is always one of: 'none', 'soft', 'hard'.
+ * Each tier returns null to signal "no override here — fall through to the
+ * next tier". The global tier always returns a concrete value.
  *
- * Usage:
- *   $policy = PolicyResolver::resolve( $post_id );
- *   // 'none' → issue token, no gate
- *   // 'soft' → show skippable gate modal
- *   // 'hard' → email required before token is issued
+ * Return value is one of: 'none' | 'soft' | 'hard' | 'disabled'.
+ * - 'disabled' means the download affordance should be hidden entirely.
+ * - 'none'     means issue a token with no gate.
+ * - 'soft'     means show a skippable gate modal.
+ * - 'hard'     means email is required before a token is issued.
  *
  * @package WT\DownloadGateway
  */
@@ -31,7 +30,7 @@ class PolicyResolver {
 	 * Resolve the effective gate policy for a given post ID.
 	 *
 	 * @param int $post_id Post ID of the downloadable item.
-	 * @return string 'none'|'soft'|'hard'
+	 * @return string 'none'|'soft'|'hard'|'disabled'
 	 */
 	public static function resolve( int $post_id ): string {
 		// Tier 1 — per-resource override.
@@ -41,11 +40,11 @@ class PolicyResolver {
 			return $per_resource;
 		}
 
-		// Tier 2 — taxonomy default.
-		$taxonomy = self::resolve_taxonomy( $post_id );
-		if ( null !== $taxonomy ) {
-			Logger::debug( "PolicyResolver: taxonomy policy '{$taxonomy}' for post {$post_id}." );
-			return $taxonomy;
+		// Tier 2 — per-CPT default.
+		$per_cpt = self::resolve_per_cpt( $post_id );
+		if ( null !== $per_cpt ) {
+			Logger::debug( "PolicyResolver: per-CPT policy '{$per_cpt}' for post {$post_id}." );
+			return $per_cpt;
 		}
 
 		// Tier 3 — global default.
@@ -63,45 +62,28 @@ class PolicyResolver {
 	 */
 	private static function resolve_per_resource( int $post_id ): ?string {
 		$value = get_post_meta( $post_id, self::META_KEY, true );
-		return self::validate_policy( $value );
+		return self::validate_concrete( $value );
 	}
 
 	/**
-	 * Returns a taxonomy-level policy if any registered taxonomy on this post
-	 * has a gateway_gate_policy term meta value set, or null to fall through.
-	 *
-	 * Currently inactive — no taxonomy has gateway gate meta set until sub-phase 4
-	 * ACF fields are added. The tier is wired here so precedence is correct from
-	 * the start; no code changes needed in sub-phase 4 beyond writing the term meta.
+	 * Returns the per-CPT policy if set for this post's type, or null to fall through.
 	 */
-	private static function resolve_taxonomy( int $post_id ): ?string {
-		$post_type  = get_post_type( $post_id );
-		$taxonomies = get_object_taxonomies( $post_type );
-
-		foreach ( $taxonomies as $taxonomy ) {
-			$terms = get_the_terms( $post_id, $taxonomy );
-			if ( ! $terms || is_wp_error( $terms ) ) {
-				continue;
-			}
-			foreach ( $terms as $term ) {
-				$value = get_term_meta( $term->term_id, 'gateway_gate_policy', true );
-				$valid = self::validate_policy( $value );
-				if ( null !== $valid ) {
-					return $valid;
-				}
-			}
+	private static function resolve_per_cpt( int $post_id ): ?string {
+		$post_type = get_post_type( $post_id );
+		if ( ! $post_type ) {
+			return null;
 		}
-
-		return null;
+		return SettingsRepository::get_cpt_policy( $post_type );
 	}
 
 	/**
-	 * Returns the value if it is a valid policy string, or null otherwise.
+	 * Returns the value if it is a concrete policy string, or null otherwise.
 	 *
-	 * @param mixed $value Raw value from postmeta or term meta.
+	 * @param mixed $value Raw value from postmeta or options.
 	 */
-	private static function validate_policy( mixed $value ): ?string {
-		$valid = array( SettingsRepository::POLICY_NONE, SettingsRepository::POLICY_SOFT, SettingsRepository::POLICY_HARD );
-		return ( is_string( $value ) && in_array( $value, $valid, true ) ) ? $value : null;
+	private static function validate_concrete( mixed $value ): ?string {
+		return ( is_string( $value ) && in_array( $value, SettingsRepository::concrete_policies(), true ) )
+			? $value
+			: null;
 	}
 }

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -48,7 +48,7 @@ class Resource_Metabox {
 			return;
 		}
 
-		$allowed = array( '', 'none', 'soft', 'hard' );
+		$allowed = array_merge( array( '' ), SettingsRepository::allowed_override_values() );
 		$value   = isset( $_POST['_gateway_gate_policy'] )
 			? sanitize_key( $_POST['_gateway_gate_policy'] )
 			: '';
@@ -68,10 +68,11 @@ class Resource_Metabox {
 		?>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Gate policy</p>
 		<select name="_gateway_gate_policy" style="width:100%;margin-bottom:10px;">
-			<option value=""  <?php selected( $policy, '' ); ?>>Inherit (use global default)</option>
-			<option value="none" <?php selected( $policy, 'none' ); ?>>None — direct redirect</option>
-			<option value="soft" <?php selected( $policy, 'soft' ); ?>>Soft gate — skippable prompt</option>
-			<option value="hard" <?php selected( $policy, 'hard' ); ?>>Hard gate — email required</option>
+			<option value=""       <?php selected( $policy, '' ); ?>>Inherit (use CPT / global default)</option>
+			<option value="none"     <?php selected( $policy, 'none' ); ?>>None — direct redirect</option>
+			<option value="soft"     <?php selected( $policy, 'soft' ); ?>>Soft gate — skippable prompt</option>
+			<option value="hard"     <?php selected( $policy, 'hard' ); ?>>Hard gate — email required</option>
+			<option value="disabled" <?php selected( $policy, 'disabled' ); ?>>Disabled — hide download link</option>
 		</select>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Download URL</p>
 		<input

--- a/wp-content/plugins/download-gateway/includes/class-settings-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-settings-repository.php
@@ -1,13 +1,10 @@
 <?php
 /**
- * SettingsRepository — typed read access to gateway wp_options.
+ * SettingsRepository — typed read/write access to gateway wp_options.
  *
  * All options are stored under the `gateway_` prefix. Defaults are defined
  * here so callers never receive null — add a getter and a default constant
  * for every new setting added in future sub-phases.
- *
- * Writing settings is handled by the Settings_Page form (sub-phase 2b+);
- * this class is read-only.
  *
  * @package WT\DownloadGateway
  */
@@ -20,24 +17,78 @@ class SettingsRepository {
 	const OPTION_GLOBAL_GATE_POLICY = 'gateway_global_gate_policy';
 	const OPTION_RETENTION_MONTHS   = 'gateway_retention_months';
 
-	// Valid gate policy values.
-	const POLICY_NONE = 'none';
-	const POLICY_SOFT = 'soft';
-	const POLICY_HARD = 'hard';
+	/** Option key pattern for per-CPT policy. Sprintf with post_type. */
+	const OPTION_CPT_POLICY_PREFIX = 'gateway_cpt_policy_';
+
+	// Valid gate policy values (concrete — used as effective resolved values).
+	const POLICY_NONE     = 'none';
+	const POLICY_SOFT     = 'soft';
+	const POLICY_HARD     = 'hard';
+	const POLICY_DISABLED = 'disabled';
+
+	/** Sentinel value meaning "use the next tier down". Never returned by PolicyResolver::resolve(). */
+	const POLICY_INHERIT = 'inherit';
 
 	// Defaults.
 	const DEFAULT_GLOBAL_GATE_POLICY = self::POLICY_NONE;
 	const DEFAULT_RETENTION_MONTHS   = 24;
 
 	/**
-	 * Returns the site-wide gate policy: 'none', 'soft', or 'hard'.
-	 * Overridden per-resource or per-taxonomy by PolicyResolver.
+	 * All concrete policy values (valid as a resolved effective policy).
+	 *
+	 * @return string[]
+	 */
+	public static function concrete_policies(): array {
+		return array( self::POLICY_NONE, self::POLICY_SOFT, self::POLICY_HARD, self::POLICY_DISABLED );
+	}
+
+	/**
+	 * All values accepted as a stored override (concrete + inherit sentinel).
+	 *
+	 * @return string[]
+	 */
+	public static function allowed_override_values(): array {
+		return array( self::POLICY_NONE, self::POLICY_SOFT, self::POLICY_HARD, self::POLICY_DISABLED, self::POLICY_INHERIT );
+	}
+
+	/**
+	 * Returns the site-wide gate policy: 'none', 'soft', 'hard', or 'disabled'.
+	 * Overridden per-CPT or per-resource by PolicyResolver.
 	 */
 	public static function get_global_gate_policy(): string {
 		$value = get_option( self::OPTION_GLOBAL_GATE_POLICY, self::DEFAULT_GLOBAL_GATE_POLICY );
-		return in_array( $value, array( self::POLICY_NONE, self::POLICY_SOFT, self::POLICY_HARD ), true )
+		return in_array( $value, self::concrete_policies(), true )
 			? $value
 			: self::DEFAULT_GLOBAL_GATE_POLICY;
+	}
+
+	/**
+	 * Returns the per-CPT policy for the given post type, or null if not set
+	 * (i.e. it inherits from the global default).
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @return string|null Concrete policy value or null to inherit.
+	 */
+	public static function get_cpt_policy( string $post_type ): ?string {
+		$value = get_option( self::OPTION_CPT_POLICY_PREFIX . $post_type, self::POLICY_INHERIT );
+		return in_array( $value, self::concrete_policies(), true ) ? $value : null;
+	}
+
+	/**
+	 * Persist a per-CPT policy override.
+	 *
+	 * Pass POLICY_INHERIT (or any non-concrete value) to clear the override and
+	 * fall back to the global default.
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @param string $policy    Policy value.
+	 */
+	public static function update_cpt_policy( string $post_type, string $policy ): void {
+		if ( in_array( $policy, self::concrete_policies(), true ) ) {
+			update_option( self::OPTION_CPT_POLICY_PREFIX . $post_type, $policy );
+		} else {
+			delete_option( self::OPTION_CPT_POLICY_PREFIX . $post_type );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **PolicyResolver**: replaces the inactive taxonomy tier with a per-CPT tier. Resolution order: per-resource → per-CPT → global. Adds `disabled` as a concrete policy value (signals templates to hide the download affordance entirely).
- **SettingsRepository**: adds `POLICY_DISABLED`, `POLICY_INHERIT` constants; `concrete_policies()` / `allowed_override_values()` helpers; `get_cpt_policy()` / `update_cpt_policy()` for per-CPT option storage.
- **Download_Shortcode**: returns empty string when resolved policy is `disabled`.
- **Resource_Metabox**: adds `disabled` option; updates inherit label to "Inherit (use CPT / global default)".
- **Settings_Page**: per-CPT policy rows (one per registered post type); audit table of all posts with non-inherit per-resource overrides; `gateway_policy_post_types` filter. `videos` and `captions` bridged via filter until sub-phase 6 FileResolvers land (comment marks the cleanup point).
- **plan.md**: splits 5b into 5b-i / 5b-ii; marks sub-phase 9 complete.

## Test plan

- [ ] Settings page shows Global default + document_files / videos / captions CPT rows + retention row
- [ ] Save per-CPT policy for each type — confirm persists on reload
- [ ] Set a resource to `disabled` via metabox — confirm shortcode renders empty, download link hidden
- [ ] Set a CPT policy — confirm per-resource `inherit` falls through to CPT value
- [ ] Audit table shows posts with explicit overrides; empty state message when none set
- [ ] All 144 tests passing, lint + PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)