### PR TITLE
feat(gateway): sub-phase 5b-ii intake form infrastructure

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,11 @@ parameters:
 			path: tests/unit/download-gateway/RetentionJobTest.php
 
 		-
+			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:once\\(\\)\\.$#"
+			count: 2
+			path: tests/unit/download-gateway/IntakeControllerTest.php
+
+		-
 			message: "#^Call to an undefined method Mockery\\\\ExpectationInterface\\|Mockery\\\\HigherOrderMessage\\:\\:twice\\(\\)\\.$#"
 			count: 1
 			path: tests/unit/download-gateway/GateControllerTest.php

--- a/plan.md
+++ b/plan.md
@@ -237,19 +237,8 @@ Downloads currently go through unprotected direct file URLs or `force_download_f
 - [x] **3** — Download endpoint: `GET /wp-json/gateway/v1/download/{token-or-post-id}`, `gateway_vid` visitor cookie, click + redirect event logging, IP hashing, no-cache headers. Tested on localhost — 302 redirect confirmed (PR #560)
 - [x] **4** — Resource authoring: native WP metabox (gate policy select + file URL + shortcode snippet), `[gateway_download]` shortcode. All three validated on localhost. (PR #561)
 - [x] **5** — Gate modes: soft (skippable modal) and hard (email required); `POST /wp-json/gateway/v1/gate`; PeopleRepository upsert; one-time token; nonce + rate limit + honeypot; silent passthrough via `gateway_gated` cookie. All policy permutations validated on localhost. (PR #561)
-- **5b-i** — Policy model expansion _(in progress)_:
-  - Replace taxonomy tier with per-CPT tier in `PolicyResolver`; add `disabled` as a policy value (hides download affordance entirely)
-  - `SettingsRepository::get_cpt_policy()` + `update_cpt_policy()`; `concrete_policies()` + `allowed_override_values()` helpers
-  - `gateway_policy_post_types` filter — defaults to `FileResolverRegistry::registered_post_types()`; videos + captions added via filter until their FileResolvers land in sub-phase 6 (remove filter entries at that point)
-  - Settings page: per-CPT policy rows; admin audit table of all posts with non-inherit per-resource overrides
-  - `Download_Shortcode`: return empty string when policy resolves to `disabled`
-  - `Resource_Metabox`: add `disabled` option; update inherit label to "Inherit (use CPT / global default)"
-- **5b-ii** — Intake form infrastructure:
-  - `wp_gateway_intake_responses` table; bump schema version
-  - `gateway_intake_fields` PHP filter; fields registered in theme/CPT code; gateway plugin is field-agnostic
-  - `IntakeController`: `POST /gateway/v1/intake`; stores response blob per person+post
-  - `wp_localize_script`: add `intakeSteps[postType]` payload
-  - Multi-step modal JS: step 2 rendered from `gatewaySettings.intakeSteps[postType]` (only shown when fields are defined for the CPT)
+- [x] **5b-i** — Policy model expansion: per-CPT tier, `disabled` value, settings UI audit table, shortcode + metabox updates. (PR #566)
+- [x] **5b-ii** — Intake form infrastructure: `wp_gateway_intake_responses` table (schema v2), `plugins_loaded` upgrade hook, `IntakeRepository`, `IntakeController` (`POST /gateway/v1/intake`), `intakeSteps`/`intakeUrl` localized to JS, multi-step modal (step 2 field rendering, submit/skip, `proceedAfterGate`). (PR #567)
 - **6** — Storage adapters + Dropbox: local/media/external adapters; Dropbox adapter calls `files/get_temporary_link`, caches briefly, stores credentials in `wp_options` with `autoload=no`
 - **7** — GA4 forwarding: EventBus subscriber; client-side where possible; events: `resource_download_click`, `resource_download_gate_submit`, `resource_download_redirect`
 - **8** — Admin reporting: date-filtered download table, top resources, CSV export with capability check

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,8 @@ require_once GATEWAY_DIR . 'includes/class-download-event-repository.php';
 require_once GATEWAY_DIR . 'includes/class-download-controller.php';
 require_once GATEWAY_DIR . 'includes/class-people-repository.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
+require_once GATEWAY_DIR . 'includes/class-intake-repository.php';
+require_once GATEWAY_DIR . 'includes/class-intake-controller.php';
 require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 
 require_once __DIR__ . '/../wp-content/themes/blankslate-child/includes/integrations/acf-helpers.php';

--- a/tests/unit/download-gateway/IntakeControllerTest.php
+++ b/tests/unit/download-gateway/IntakeControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use WT\DownloadGateway\IntakeController;
+
+class IntakeControllerTest extends TestCase {
+
+	private IntakeController $controller;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->controller = new IntakeController();
+
+		WP_Mock::userFunction( 'sanitize_key', array( 'return_arg' => 0 ) );
+		WP_Mock::userFunction( 'sanitize_text_field', array( 'return_arg' => 0 ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// Nonce / param validation
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_403_for_invalid_nonce(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => false ) );
+
+		$result = $this->controller->submit( 42, 7, 'bad-nonce', array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	public function test_submit_returns_400_for_invalid_post_id(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+
+		$result = $this->controller->submit( 0, 7, 'valid-nonce', array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_submit_returns_400_for_invalid_person_id(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+
+		$result = $this->controller->submit( 42, 0, 'valid-nonce', array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	public function test_submit_returns_404_when_post_not_found(): void {
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => false ) );
+
+		$result = $this->controller->submit( 42, 7, 'valid-nonce', array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// DB error path
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_500_when_db_insert_fails(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'insert' )->once()->andReturn( false );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'document_files' ) );
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-16 10:00:00' ) );
+		WP_Mock::userFunction( 'wp_json_encode', array( 'return' => '{}' ) );
+
+		$result = $this->controller->submit( 42, 7, 'valid-nonce', array() );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Happy path
+	// -------------------------------------------------------------------------
+
+	public function test_submit_returns_true_on_success(): void {
+		/** @var \Mockery\MockInterface&\wpdb $wpdb */
+		$wpdb         = Mockery::mock( 'wpdb' );
+		$wpdb->prefix = 'wp_';
+		$wpdb->shouldReceive( 'insert' )->once()->andReturn( 1 );
+		$GLOBALS['wpdb'] = $wpdb;
+
+		WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => 1 ) );
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'document_files' ) );
+		WP_Mock::userFunction( 'current_time', array( 'return' => '2026-03-16 10:00:00' ) );
+		WP_Mock::userFunction(
+			'wp_json_encode',
+			array( 'return' => '{"use_case":"research"}' )
+		);
+
+		$result = $this->controller->submit(
+			42,
+			7,
+			'valid-nonce',
+			array( 'use_case' => 'research' )
+		);
+
+		$this->assertTrue( $result );
+	}
+}

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -2,7 +2,8 @@
 ( function () {
 	'use strict';
 
-	// gatewaySettings is localized by PHP: { nonce, apiUrl, downloadBase }
+	// gatewaySettings is localized by PHP:
+	//   { nonce, restNonce, apiUrl, downloadBase, intakeUrl, intakeSteps }
 	if ( typeof gatewaySettings === 'undefined' ) {
 		return;
 	}
@@ -25,11 +26,30 @@
 	}
 
 	// -------------------------------------------------------------------------
+	// HTML helpers (used when building intake field markup from PHP-supplied data)
+	// -------------------------------------------------------------------------
+
+	function escHtml( str ) {
+		return String( str )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' );
+	}
+
+	function escAttr( str ) {
+		return String( str )
+			.replace( /&/g, '&amp;' )
+			.replace( /"/g, '&quot;' );
+	}
+
+	// -------------------------------------------------------------------------
 	// Modal DOM
 	// -------------------------------------------------------------------------
 
-	var modal, overlay, form, nameField, emailField, consentField,
+	var modal, overlay, gateContainer, form, nameField, emailField, consentField,
 		honeypotField, errorMsg, submitBtn, skipBtn, closeBtn;
+	var intakeContainer, intakeForm, intakeErrorMsg, intakeSubmitBtn, intakeSkipBtn;
 
 	function buildModal() {
 		overlay = document.createElement( 'div' );
@@ -43,8 +63,11 @@
 
 		modal.innerHTML =
 			'<button id="gateway-close" aria-label="Close">&times;</button>' +
+
+			// ── Step 1: gate form ──────────────────────────────────────────
+			'<div id="gateway-gate-container">' +
 			'<h2 id="gateway-modal-title">Download this resource</h2>' +
-			'<p id="gateway-modal-desc">Share your name and email to download. Wikitongues will occasionally send you updates about our work — you can unsubscribe at any time.</p>' +
+			'<p id="gateway-modal-desc">Share your name and email to download. Wikitongues will occasionally send you updates about our work \u2014 you can unsubscribe at any time.</p>' +
 			'<form id="gateway-form" novalidate>' +
 				'<label for="gateway-name">Name <span aria-hidden="true">*</span></label>' +
 				'<input id="gateway-name" name="name" type="text" autocomplete="name" required />' +
@@ -63,44 +86,79 @@
 					'<button id="gateway-submit" type="submit">Download</button>' +
 					'<button id="gateway-skip" type="button">Download without sharing</button>' +
 				'</div>' +
-			'</form>';
+			'</form>' +
+			'</div>' +
+
+			// ── Step 2: intake form (hidden until gate passes) ─────────────
+			'<div id="gateway-intake-container" style="display:none">' +
+			'<h2 id="gateway-intake-title">One more thing</h2>' +
+			'<p id="gateway-intake-desc">Help us understand how you\'ll use this resource. This is optional.</p>' +
+			'<form id="gateway-intake-form" novalidate></form>' +
+			'<p id="gateway-intake-error" role="alert" aria-live="assertive"></p>' +
+			'<div class="gateway-actions">' +
+				'<button id="gateway-intake-submit" type="button">Submit &amp; Download</button>' +
+				'<button id="gateway-intake-skip" type="button">Skip &amp; Download</button>' +
+			'</div>' +
+			'</div>';
 
 		overlay.appendChild( modal );
 		document.body.appendChild( overlay );
 
-		form        = document.getElementById( 'gateway-form' );
-		nameField   = document.getElementById( 'gateway-name' );
-		emailField  = document.getElementById( 'gateway-email' );
-		consentField = document.getElementById( 'gateway-consent' );
+		// Gate step
+		gateContainer = document.getElementById( 'gateway-gate-container' );
+		form          = document.getElementById( 'gateway-form' );
+		nameField     = document.getElementById( 'gateway-name' );
+		emailField    = document.getElementById( 'gateway-email' );
+		consentField  = document.getElementById( 'gateway-consent' );
 		honeypotField = document.getElementById( 'gateway-hp' );
-		errorMsg    = document.getElementById( 'gateway-error' );
-		submitBtn   = document.getElementById( 'gateway-submit' );
-		skipBtn     = document.getElementById( 'gateway-skip' );
-		closeBtn    = document.getElementById( 'gateway-close' );
+		errorMsg      = document.getElementById( 'gateway-error' );
+		submitBtn     = document.getElementById( 'gateway-submit' );
+		skipBtn       = document.getElementById( 'gateway-skip' );
+		closeBtn      = document.getElementById( 'gateway-close' );
+
+		// Intake step
+		intakeContainer = document.getElementById( 'gateway-intake-container' );
+		intakeForm      = document.getElementById( 'gateway-intake-form' );
+		intakeErrorMsg  = document.getElementById( 'gateway-intake-error' );
+		intakeSubmitBtn = document.getElementById( 'gateway-intake-submit' );
+		intakeSkipBtn   = document.getElementById( 'gateway-intake-skip' );
 	}
 
 	// -------------------------------------------------------------------------
 	// Modal open / close
 	// -------------------------------------------------------------------------
 
-	var currentPostId = null;
+	var currentPostId    = null;
+	var currentPostType  = null;
 	var currentDirectUrl = null;
 
-	function openModal( postId, policy, directUrl ) {
+	// Pending state — populated when gate passes and intake step is active.
+	var pendingToken     = null;
+	var pendingPersonId  = null;
+	var pendingPostId    = null;
+	var pendingPostType  = null;
+	var pendingDirectUrl = null;
+
+	function openModal( postId, policy, directUrl, postType ) {
 		if ( ! modal ) {
 			buildModal();
 			attachModalEvents();
 		}
 
 		currentPostId    = postId;
+		currentPostType  = postType || '';
 		currentDirectUrl = directUrl;
 
-		errorMsg.textContent = '';
+		// Reset to gate step.
+		errorMsg.textContent          = '';
 		form.reset();
 		setLoading( false );
+		gateContainer.style.display   = '';
+		intakeContainer.style.display = 'none';
+		clearPending();
 
-		// Skip button only shown for soft gate
-		skipBtn.style.display = policy === 'soft' ? '' : 'none';
+		// Skip / close only shown for soft gate.
+		skipBtn.style.display  = policy === 'soft' ? '' : 'none';
 		closeBtn.style.display = policy === 'soft' ? '' : 'none';
 
 		overlay.classList.add( 'is-open' );
@@ -110,11 +168,21 @@
 	function closeModal() {
 		overlay.classList.remove( 'is-open' );
 		currentPostId    = null;
+		currentPostType  = null;
 		currentDirectUrl = null;
+		clearPending();
+	}
+
+	function clearPending() {
+		pendingToken     = null;
+		pendingPersonId  = null;
+		pendingPostId    = null;
+		pendingPostType  = null;
+		pendingDirectUrl = null;
 	}
 
 	function setLoading( loading ) {
-		submitBtn.disabled = loading;
+		submitBtn.disabled    = loading;
 		submitBtn.textContent = loading ? 'Downloading\u2026' : 'Download';
 	}
 
@@ -127,32 +195,59 @@
 	// -------------------------------------------------------------------------
 
 	function attachModalEvents() {
-		// Close on overlay click (soft gate only — hard gate has no close btn)
+		// Close on overlay click — in intake step this finishes the download.
 		overlay.addEventListener( 'click', function ( e ) {
-			if ( e.target === overlay && skipBtn.style.display !== 'none' ) {
+			if ( e.target !== overlay ) { return; }
+			if ( pendingToken !== null ) {
+				finishDownload( pendingToken, pendingDirectUrl );
+			} else if ( skipBtn.style.display !== 'none' ) {
 				closeModal();
 			}
 		} );
 
-		closeBtn.addEventListener( 'click', closeModal );
+		// Close button — in intake step this finishes the download.
+		closeBtn.addEventListener( 'click', function () {
+			if ( pendingToken !== null ) {
+				finishDownload( pendingToken, pendingDirectUrl );
+			} else {
+				closeModal();
+			}
+		} );
 
+		// Gate skip: download without sharing.
 		skipBtn.addEventListener( 'click', function () {
 			var url = currentDirectUrl;
 			closeModal();
 			redirect( url );
 		} );
 
+		// Gate form submit.
 		form.addEventListener( 'submit', function ( e ) {
 			e.preventDefault();
-			handleSubmit();
+			handleGateSubmit();
+		} );
+
+		// Intake submit.
+		intakeSubmitBtn.addEventListener( 'click', handleIntakeSubmit );
+
+		// Intake skip: proceed to download without saving intake responses.
+		intakeSkipBtn.addEventListener( 'click', function () {
+			var token = pendingToken;
+			var url   = pendingDirectUrl;
+			closeModal();
+			if ( token ) {
+				downloadViaToken( token, url );
+			} else {
+				redirect( url );
+			}
 		} );
 	}
 
 	// -------------------------------------------------------------------------
-	// Form submission
+	// Gate form submission
 	// -------------------------------------------------------------------------
 
-	function handleSubmit() {
+	function handleGateSubmit() {
 		var name    = nameField.value.trim();
 		var email   = emailField.value.trim();
 		var consent = consentField.checked;
@@ -196,21 +291,179 @@
 					showError( result.data.message || 'Something went wrong. Please try again.' );
 					return;
 				}
-				var directUrl = currentDirectUrl;
 				setCookie( 'gateway_gated', result.data.person_id, 30 );
-				closeModal();
-				var token = result.data.token;
-				if ( token ) {
-					downloadViaToken( token, directUrl );
-				} else {
-					// Honeypot hit — silently redirect to direct URL
-					redirect( directUrl );
-				}
+				proceedAfterGate(
+					result.data.token,
+					result.data.person_id,
+					currentPostId,
+					currentPostType,
+					currentDirectUrl
+				);
 			} )
 			.catch( function () {
 				setLoading( false );
 				showError( 'A network error occurred. Please try again.' );
 			} );
+	}
+
+	// -------------------------------------------------------------------------
+	// After-gate routing
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Decide what happens after a successful gate submission.
+	 *
+	 * If the post type has intake fields registered via the gateway_intake_fields
+	 * filter, show step 2. Otherwise download immediately.
+	 */
+	function proceedAfterGate( token, personId, postId, postType, directUrl ) {
+		var steps = gatewaySettings.intakeSteps &&
+		            gatewaySettings.intakeSteps[ postType ];
+		if ( token && steps && steps.length ) {
+			pendingToken     = token;
+			pendingPersonId  = personId;
+			pendingPostId    = postId;
+			pendingPostType  = postType;
+			pendingDirectUrl = directUrl;
+			showIntakeStep( steps );
+		} else if ( token ) {
+			closeModal();
+			downloadViaToken( token, directUrl );
+		} else {
+			// Honeypot hit — silently redirect to direct URL.
+			closeModal();
+			redirect( directUrl );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Intake step
+	// -------------------------------------------------------------------------
+
+	function showIntakeStep( fields ) {
+		intakeForm.innerHTML          = buildIntakeFieldsHtml( fields );
+		intakeErrorMsg.textContent    = '';
+		intakeSubmitBtn.disabled      = false;
+		intakeSubmitBtn.textContent   = 'Submit & Download';
+		gateContainer.style.display   = 'none';
+		intakeContainer.style.display = '';
+		var firstInput = intakeForm.querySelector( 'input, textarea, select' );
+		if ( firstInput ) {
+			firstInput.focus();
+		}
+	}
+
+	/**
+	 * Build the HTML for the intake form fields from a field definitions array.
+	 *
+	 * Field definition shape (mirrors gateway_intake_fields PHP filter):
+	 *   key      — machine name used as the form element name and response key
+	 *   label    — human-readable label
+	 *   type     — text | textarea | select | radio | checkbox
+	 *   options  — object of { value: label } pairs (select and radio only)
+	 */
+	function buildIntakeFieldsHtml( fields ) {
+		var html = '';
+		for ( var i = 0; i < fields.length; i++ ) {
+			var field = fields[ i ];
+			var key   = field.key   || '';
+			var label = field.label || '';
+			var type  = field.type  || 'text';
+			var id    = 'gateway-intake-' + key;
+			var opts, optKey;
+
+			html += '<div class="gateway-intake-field">';
+
+			if ( type === 'radio' || type === 'checkbox' ) {
+				html += '<fieldset><legend>' + escHtml( label ) + '</legend>';
+				opts = field.options || {};
+				for ( optKey in opts ) {
+					if ( Object.prototype.hasOwnProperty.call( opts, optKey ) ) {
+						html +=
+							'<label class="gateway-intake-option">' +
+							'<input type="' + type + '" name="' + escAttr( key ) + '" value="' + escAttr( optKey ) + '" /> ' +
+							escHtml( opts[ optKey ] ) +
+							'</label>';
+					}
+				}
+				html += '</fieldset>';
+			} else {
+				html += '<label for="' + escAttr( id ) + '">' + escHtml( label ) + '</label>';
+				if ( type === 'textarea' ) {
+					html += '<textarea id="' + escAttr( id ) + '" name="' + escAttr( key ) + '"></textarea>';
+				} else if ( type === 'select' ) {
+					html += '<select id="' + escAttr( id ) + '" name="' + escAttr( key ) + '">';
+					html += '<option value="">\u2014 Select \u2014</option>';
+					opts = field.options || {};
+					for ( optKey in opts ) {
+						if ( Object.prototype.hasOwnProperty.call( opts, optKey ) ) {
+							html += '<option value="' + escAttr( optKey ) + '">' + escHtml( opts[ optKey ] ) + '</option>';
+						}
+					}
+					html += '</select>';
+				} else {
+					html += '<input type="text" id="' + escAttr( id ) + '" name="' + escAttr( key ) + '" />';
+				}
+			}
+
+			html += '</div>';
+		}
+		return html;
+	}
+
+	function handleIntakeSubmit() {
+		var token     = pendingToken;
+		var personId  = pendingPersonId;
+		var postId    = pendingPostId;
+		var directUrl = pendingDirectUrl;
+
+		// Collect responses from intake form fields.
+		var responses = {};
+		var elements  = intakeForm.elements;
+		for ( var i = 0; i < elements.length; i++ ) {
+			var el = elements[ i ];
+			if ( ! el.name ) { continue; }
+			if ( ( el.type === 'radio' || el.type === 'checkbox' ) && ! el.checked ) { continue; }
+			responses[ el.name ] = el.value;
+		}
+
+		intakeSubmitBtn.disabled    = true;
+		intakeSubmitBtn.textContent = 'Saving\u2026';
+		intakeErrorMsg.textContent  = '';
+
+		fetch( gatewaySettings.intakeUrl, {
+			method:      'POST',
+			credentials: 'same-origin',
+			headers:     {
+				'Content-Type': 'application/json',
+				'X-WP-Nonce':   gatewaySettings.restNonce,
+			},
+			body: JSON.stringify( {
+				post_id:   postId,
+				person_id: personId,
+				nonce:     gatewaySettings.nonce,
+				responses: responses,
+			} ),
+		} )
+			.then( function () {
+				// Intake is supplementary — proceed regardless of server response.
+				finishDownload( token, directUrl );
+			} )
+			.catch( function () {
+				finishDownload( token, directUrl );
+			} );
+	}
+
+	/**
+	 * Close the modal and trigger the download. Called after intake submit or skip.
+	 */
+	function finishDownload( token, directUrl ) {
+		closeModal();
+		if ( token ) {
+			downloadViaToken( token, directUrl );
+		} else {
+			redirect( directUrl );
+		}
 	}
 
 	// -------------------------------------------------------------------------
@@ -229,8 +482,8 @@
 	 * avoids leaving an intermediate token URL in the browser's history stack.
 	 * Falls back to a direct token-URL navigation if the JSON request fails.
 	 *
-	 * @param {string} token      64-char hex download token.
-	 * @param {string} fallback   URL to navigate to if the JSON request fails.
+	 * @param {string} token    64-char hex download token.
+	 * @param {string} fallback URL to navigate to if the JSON request fails.
 	 */
 	function downloadViaToken( token, fallback ) {
 		fetch( gatewaySettings.downloadBase + '/' + token + '?format=json', {
@@ -253,7 +506,7 @@
 	 * Falls back to the modal if the server rejects the passthrough
 	 * (e.g. person was anonymized).
 	 */
-	function doSilentPassthrough( postId, policy, personId, directUrl ) {
+	function doSilentPassthrough( postId, policy, personId, directUrl, postType ) {
 		var body = new URLSearchParams( {
 			post_id:      postId,
 			_passthrough: personId,
@@ -274,7 +527,7 @@
 			.then( function ( result ) {
 				if ( ! result.ok ) {
 					// Passthrough rejected — show gate form.
-					openModal( postId, policy, directUrl );
+					openModal( postId, policy, directUrl, postType );
 					return;
 				}
 				setCookie( 'gateway_gated', result.data.person_id, 30 );
@@ -282,7 +535,7 @@
 			} )
 			.catch( function () {
 				// Network error — fall back to modal.
-				openModal( postId, policy, directUrl );
+				openModal( postId, policy, directUrl, postType );
 			} );
 	}
 
@@ -302,9 +555,9 @@
 
 		var personId = getCookie( 'gateway_gated' );
 		if ( personId ) {
-			doSilentPassthrough( link.dataset.postId, policy, personId, link.href );
+			doSilentPassthrough( link.dataset.postId, policy, personId, link.href, link.dataset.postType );
 		} else {
-			openModal( link.dataset.postId, policy, link.href );
+			openModal( link.dataset.postId, policy, link.href, link.dataset.postType );
 		}
 	} );
 }() );

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -50,6 +50,8 @@ require_once GATEWAY_DIR . 'includes/class-resource-metabox.php';
 require_once GATEWAY_DIR . 'includes/class-download-shortcode.php';
 require_once GATEWAY_DIR . 'includes/class-people-repository.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
+require_once GATEWAY_DIR . 'includes/class-intake-repository.php';
+require_once GATEWAY_DIR . 'includes/class-intake-controller.php';
 require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 require_once GATEWAY_DIR . 'includes/admin/class-settings-page.php';
 
@@ -80,6 +82,21 @@ add_action(
 add_action( 'admin_menu', __NAMESPACE__ . '\Settings_Page::register' );
 add_action( 'admin_init', __NAMESPACE__ . '\Settings_Page::handle_run_now_action' );
 
+/*
+ * Auto-upgrade the DB schema when the plugin is updated.
+ * create_tables() uses dbDelta() so it is safe to run on every load when
+ * the version check passes — it only adds missing tables/columns.
+ */
+add_action(
+	'plugins_loaded',
+	function (): void {
+		$installed = (int) get_option( Schema::VERSION_OPTION, 0 );
+		if ( $installed < Schema::SCHEMA_VERSION ) {
+			Schema::create_tables();
+		}
+	}
+);
+
 add_action(
 	'rest_api_init',
 	function (): void {
@@ -87,6 +104,7 @@ add_action(
 		if ( GATEWAY_ENABLED ) {
 			( new DownloadController() )->register_routes();
 			( new GateController() )->register_routes();
+			( new IntakeController() )->register_routes();
 		}
 	}
 );
@@ -112,6 +130,28 @@ add_action(
 			GATEWAY_VERSION,
 			true
 		);
+		/**
+		 * Filters intake field definitions for the download modal step 2.
+		 *
+		 * Return an array keyed by post type slug. Each value is an array of
+		 * field definition arrays with keys:
+		 *   key      — machine name (used as the response key in the DB)
+		 *   label    — human-readable label
+		 *   type     — text | textarea | select | radio | checkbox
+		 *   options  — assoc array of value => label (select / radio only)
+		 *   required — bool (currently informational; JS does not enforce)
+		 *
+		 * Example:
+		 *   add_filter( 'gateway_intake_fields', function( $fields ) {
+		 *       $fields['document_files'] = array(
+		 *           array( 'key' => 'use_case', 'label' => 'How will you use this?',
+		 *                  'type' => 'select', 'options' => array( 'research' => 'Research' ) ),
+		 *       );
+		 *       return $fields;
+		 *   } );
+		 *
+		 * @param array<string,array<int,array<string,mixed>>> $fields Empty by default.
+		 */
 		wp_localize_script(
 			'gateway-modal',
 			'gatewaySettings',
@@ -120,6 +160,8 @@ add_action(
 				'restNonce'    => wp_create_nonce( 'wp_rest' ),
 				'apiUrl'       => rest_url( GATEWAY_REST_NAMESPACE . '/gate' ),
 				'downloadBase' => rest_url( GATEWAY_REST_NAMESPACE . '/download' ),
+				'intakeUrl'    => rest_url( GATEWAY_REST_NAMESPACE . '/intake' ),
+				'intakeSteps'  => (array) apply_filters( 'gateway_intake_fields', array() ),
 			)
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -44,13 +44,15 @@ class Download_Shortcode {
 			return '';
 		}
 
-		$url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+		$url       = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+		$post_type = get_post_type( $post_id ) ?: '';
 
 		return sprintf(
-			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s">%s</a>',
+			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s" data-post-type="%s">%s</a>',
 			esc_url( $url ),
 			$post_id,
 			esc_attr( $policy ),
+			esc_attr( $post_type ),
 			esc_html( $atts['label'] )
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/class-intake-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-intake-controller.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * IntakeController — handles intake form submissions (modal step 2).
+ *
+ * Registers POST /wp-json/gateway/v1/intake. The testable logic lives in
+ * submit() — same pattern as GateController.
+ *
+ * Intake is supplementary: a failed save does not block the download. The
+ * endpoint returns a success response regardless so the JS always proceeds
+ * to the download redirect.
+ *
+ * Field definitions are registered via the `gateway_intake_fields` PHP filter
+ * in theme or CPT-specific code. The controller stores whatever key-value
+ * responses the JS sends — it does not validate field shape, only sanitizes.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class IntakeController {
+
+	public function register_routes(): void {
+		register_rest_route(
+			GATEWAY_REST_NAMESPACE,
+			'/intake',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'handle' ),
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+
+	/**
+	 * REST callback — not unit tested.
+	 *
+	 * @param \WP_REST_Request $request Incoming REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public function handle( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		$responses = $request->get_param( 'responses' );
+		if ( ! is_array( $responses ) ) {
+			$responses = array();
+		}
+
+		$result = $this->submit(
+			(int) ( $request->get_param( 'post_id' ) ?? 0 ),
+			(int) ( $request->get_param( 'person_id' ) ?? 0 ),
+			(string) ( $request->get_param( 'nonce' ) ?? '' ),
+			$responses
+		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new \WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Process an intake submission. Returns true on success, WP_Error on failure.
+	 *
+	 * @param int                  $post_id   Post ID of the downloaded resource.
+	 * @param int                  $person_id Person ID from wp_gateway_people.
+	 * @param string               $nonce     WP nonce value.
+	 * @param array<string,string> $responses Key-value map of field responses.
+	 * @return true|\WP_Error
+	 */
+	public function submit( int $post_id, int $person_id, string $nonce, array $responses ): bool|\WP_Error {
+		if ( ! wp_verify_nonce( $nonce, 'gateway_gate' ) ) {
+			return new \WP_Error( 'invalid_nonce', 'Request could not be verified.', array( 'status' => 403 ) );
+		}
+
+		if ( $post_id <= 0 || $person_id <= 0 ) {
+			return new \WP_Error( 'invalid_params', 'Invalid parameters.', array( 'status' => 400 ) );
+		}
+
+		$post_type = get_post_type( $post_id );
+		if ( ! $post_type ) {
+			return new \WP_Error( 'invalid_post', 'Post not found.', array( 'status' => 404 ) );
+		}
+
+		// Sanitize all response values — keys and scalar strings only.
+		$sanitized = array();
+		foreach ( $responses as $key => $value ) {
+			$sanitized[ sanitize_key( (string) $key ) ] = sanitize_text_field( (string) $value );
+		}
+
+		if ( ! IntakeRepository::save( $person_id, $post_id, $post_type, $sanitized ) ) {
+			return new \WP_Error( 'db_error', 'Could not save intake response.', array( 'status' => 500 ) );
+		}
+
+		return true;
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-intake-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-intake-repository.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * IntakeRepository — persists intake form responses to wp_gateway_intake_responses.
+ *
+ * The `responses` column is a JSON blob whose shape is determined by the
+ * `gateway_intake_fields` filter. The repository stores it opaquely so the
+ * table schema never needs to change when field definitions change.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class IntakeRepository {
+
+	/**
+	 * Persist an intake response.
+	 *
+	 * @param int                  $person_id Person ID from wp_gateway_people.
+	 * @param int                  $post_id   Post ID of the downloaded resource.
+	 * @param string               $post_type Post type slug.
+	 * @param array<string,string> $responses Key-value map of sanitized field responses.
+	 * @return bool True on success, false on DB error.
+	 */
+	public static function save( int $person_id, int $post_id, string $post_type, array $responses ): bool {
+		global $wpdb;
+
+		$result = $wpdb->insert(
+			$wpdb->prefix . 'gateway_intake_responses',
+			array(
+				'person_id'  => $person_id,
+				'post_id'    => $post_id,
+				'post_type'  => sanitize_key( $post_type ),
+				'responses'  => (string) wp_json_encode( $responses ),
+				'created_at' => current_time( 'mysql' ),
+			)
+		);
+
+		return false !== $result;
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-schema.php
+++ b/wp-content/plugins/download-gateway/includes/class-schema.php
@@ -8,10 +8,11 @@
  *
  * Table overview:
  *
- *   wp_gateway_tokens          — one-time signed download tokens (sub-phases 3, 5)
- *   wp_gateway_people          — email-known visitors captured via the gate (sub-phase 5)
- *   wp_gateway_download_events — every download lifecycle event (sub-phase 3+)
- *   wp_gateway_webhook_delivery — outbound webhook retry queue (sub-phase 2c)
+ *   wp_gateway_tokens            — one-time signed download tokens (sub-phases 3, 5)
+ *   wp_gateway_people            — email-known visitors captured via the gate (sub-phase 5)
+ *   wp_gateway_download_events   — every download lifecycle event (sub-phase 3+)
+ *   wp_gateway_webhook_delivery  — outbound webhook retry queue (sub-phase 2c)
+ *   wp_gateway_intake_responses  — per-person, per-post intake form payloads (sub-phase 5b-ii)
  *
  * @package WT\DownloadGateway
  */
@@ -24,7 +25,7 @@ class Schema {
 	const VERSION_OPTION = 'gateway_schema_version';
 
 	/** Bump this when the schema changes to trigger a migration. */
-	const SCHEMA_VERSION = 1;
+	const SCHEMA_VERSION = 2;
 
 	public static function create_tables(): void {
 		global $wpdb;
@@ -146,6 +147,28 @@ class Schema {
 				KEY event_id (event_id),
 				KEY status (status),
 				KEY next_attempt_at (next_attempt_at)
+			) $charset;"
+		);
+
+		/*
+		 * wp_gateway_intake_responses
+		 *
+		 * One record per intake form submission. The `responses` column is a
+		 * JSON blob whose shape is defined by the `gateway_intake_fields` filter
+		 * — the schema stores it opaquely so the table never needs to change
+		 * when field definitions change.
+		 */
+		dbDelta(
+			"CREATE TABLE {$wpdb->prefix}gateway_intake_responses (
+				id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+				person_id BIGINT UNSIGNED NOT NULL,
+				post_id BIGINT UNSIGNED NOT NULL,
+				post_type VARCHAR(50) NOT NULL,
+				responses LONGTEXT NOT NULL,
+				created_at DATETIME NOT NULL,
+				PRIMARY KEY (id),
+				KEY person_id (person_id),
+				KEY post_id (post_id)
 			) $charset;"
 		);
 


### PR DESCRIPTION
## Summary

- **Schema v2** — adds `wp_gateway_intake_responses` table (person_id, post_id, post_type, responses JSON blob); `plugins_loaded` auto-upgrade hook so existing installs pick up the table without reactivating
- **IntakeRepository + IntakeController** — `POST /gateway/v1/intake` validates nonce, params, and post_type; sanitizes responses; persists opaque JSON blob; never blocks download on failure (supplementary)
- **Multi-step modal JS** — after gate success, `proceedAfterGate()` checks `gatewaySettings.intakeSteps[postType]`; if fields are defined, shows step 2 with rendered form (text/textarea/select/radio/checkbox); submit POSTs responses then always proceeds to download; skip and close/overlay also proceed to download
- **Localization** — `intakeUrl` and `intakeSteps` (from `gateway_intake_fields` PHP filter) added to `gatewaySettings`; filter returns empty array by default so step 2 is invisible until fields are registered in theme/CPT code
- **Tests** — 5 new IntakeControllerTest cases (403/400/400/404/500/success), 150 total

## Test plan

- [ ] With no `gateway_intake_fields` filter registered: gate modal submits → download proceeds immediately (step 2 never shown)
- [ ] With fields registered for a CPT: gate modal submits → step 2 renders with correct fields → submit saves to `wp_gateway_intake_responses` → download proceeds
- [ ] Skip & Download on step 2 proceeds to download without saving intake
- [ ] DB insert failure on intake does not block download
- [ ] `composer test` — 150 tests pass
- [ ] `composer lint` — clean
- [ ] `composer analyse` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)