### PR TITLE
feat(gateway): sub-phase 5b-iii — intake policy configuration + session cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ vendor/
 
 # Misc
 .DS_Store
+.obsidian/
 .ftpquota
 ggstemp.html
 readme_backup.md

--- a/plan.md
+++ b/plan.md
@@ -444,6 +444,19 @@ The CPT creates the data model and public-facing profile URL (`/creators/jane-do
 
 ---
 
+#### Video state UI _(before Layer 4 — affects visual baseline)_
+
+The current video single template handles `Processing` and `Private` states with plain text messages and no affordances. Four gaps to close:
+
+- **Audio-only** — videos that are audio recordings have no video file; the thumbnail logic should detect this and show an audio-appropriate placeholder instead of a broken or absent video frame
+- **Processing** — currently shows a static message; add a "Notify me when ready" affordance (email capture, probably via the gateway people table or a lightweight subscribe endpoint)
+- **Private** — currently shows a static message; add a "Request access" affordance (sends a message to the archive team or logs a request)
+- **Thumbnail fallback logic** — audit the current thumbnail display logic across all four states (Public, Audio, Processing, Private) and define a consistent visual treatment for each
+
+**Dependency note:** No Docker dependency. Must land before Layer 4 so all state variants are captured in visual baseline screenshots.
+
+---
+
 #### Layer 4 — End-to-End & Visual Regression _(locks the visual baseline)_
 
 Playwright. Full user flows, JS behaviour, authenticated vs. unauthenticated states, visual layout regressions (screenshot diffs). Nothing that changes template output should land after this without a deliberate baseline update. See [docs/testing-strategy.md](docs/testing-strategy.md) for priority flows.

--- a/plan.md
+++ b/plan.md
@@ -342,7 +342,7 @@ Three known divergence directions:
 
 ### Phase 6 — Visual baseline + data migration
 
-_Donors must land before the Layer 4 baseline is locked so Donors UI is captured in screenshots. Stylus not required here — the baseline is captured before the preprocessor swap so regressions from that swap are caught in Phase 7. `nations_of_origin` migration requires Airtable reconciliation (Phase 5)._
+_All new CPTs and templates (Donors, Creator, Collections) must land before the Layer 4 baseline is locked so their pages are captured in screenshots. Stylus not required here — the baseline is captured before the preprocessor swap so regressions from that swap are caught in Phase 7. `nations_of_origin` migration and Creator CPT backfill require Airtable reconciliation (Phase 5)._
 
 #### Complete Donors post type
 
@@ -384,6 +384,65 @@ New `banner--campaign.php` module. `header.php` gains two ordered banner slots: 
 **What this enables:** campaign launches and banner copy changes require no deploy. EOY campaigns, point-in-time drives, and future raises are managed entirely from admin.
 
 **Dependency note:** no Docker dependency; can start independently. Must land before Layer 4 so banner UI is captured in visual baseline.
+
+#### Video collections _(before Layer 4 — collection pages must be captured in baseline)_
+
+Editorial groupings that cut across the video archive for storytelling purposes — videos recorded by a specific person, videos belonging to a named project (Jewish Languages Project), videos from a given mission trip or recording expedition.
+
+**Data model:**
+
+New `collections` CPT with its own archive and single templates. Fields:
+- `title` — display name of the collection
+- `description` — editorial context (textarea)
+- `featured_image` — cover image for the collection card
+- `videos` — ACF relationship field to the `videos` CPT (multi-select, ordered)
+- `collection_type` — taxonomy or select: `person` / `project` / `expedition` / `other`
+
+Collections appear on:
+- A new `/collections/` archive page (gallery of collection cards)
+- Individual collection pages (`/collections/jewish-languages-project/`) listing the member videos
+- Optionally: a "Part of" affordance on `single-videos.php` linking back to the collection(s) the video belongs to
+
+**Airtable sync:** Not required at launch — collections are editorially curated in WordPress. If collections map to existing Airtable structures later, a sync route can be added.
+
+**Dependency note:** No Docker dependency; no Airtable reconciliation required. Must land before Layer 4 so collection archive and single templates are included in visual baseline screenshots.
+
+---
+
+#### Creator CPT _(before Layer 4 — creator pages must be captured in baseline)_
+
+Creators already exist as a table in Airtable and are referenced on video and caption records. Bringing them into WordPress as a first-class CPT enables creator archive and profile pages, creates a named entity to link to collections and download gateway data, and is a direct precursor to a user account system.
+
+**Data model:**
+
+New `creators` CPT synced from Airtable via Make.com (same pattern as languages, videos, captions).
+
+Core fields (sourced from Airtable):
+- `name` — display name
+- `bio` — short biography
+- `profile_image` — headshot or avatar
+- `languages` — relationship to `languages` CPT (languages they speak / have documented)
+- `videos` — relationship to `videos` CPT (videos they recorded or appear in)
+- `location` — country or region
+
+WordPress-side additions:
+- `_airtable_record_id` — sync key (same pattern as all other synced CPTs)
+- `user_id` — nullable FK to `wp_users`; empty until Phase 8 membership links an account to the creator record
+
+**Make.com sync:**
+
+Add a Creators blueprint following the established pattern (Airtable webhook → WP REST sync endpoint). Linked record resolution (languages, videos) follows the subscenario pattern used by Captions.
+
+**WordPress archive and templates:**
+- `/creators/` archive — gallery of creator cards
+- `single-creators.php` — profile page: bio, languages documented, video gallery
+
+**Why before membership:**
+The CPT creates the data model and public-facing profile URL (`/creators/jane-doe/`) without requiring authentication. Phase 8 membership links a WP user account to an existing creator record via `user_id` — it does not create the record from scratch. This ordering avoids a Phase 8 data migration.
+
+**Dependency note:** Airtable reconciliation (Phase 5) should run first so creator records are clean before backfilling. Must land before Layer 4 so creator archive and single templates are included in visual baseline.
+
+---
 
 #### Layer 4 — End-to-End & Visual Regression _(locks the visual baseline)_
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,6 +44,7 @@ require_once GATEWAY_DIR . 'includes/class-person-cookie.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
 require_once GATEWAY_DIR . 'includes/class-intake-repository.php';
 require_once GATEWAY_DIR . 'includes/class-intake-controller.php';
+require_once GATEWAY_DIR . 'includes/class-intake-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 require_once GATEWAY_DIR . 'includes/class-dropbox-adapter.php';
 require_once GATEWAY_DIR . 'includes/class-video-file-resolver.php';

--- a/tests/unit/download-gateway/IntakeResolverTest.php
+++ b/tests/unit/download-gateway/IntakeResolverTest.php
@@ -1,0 +1,185 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+use WT\DownloadGateway\IntakeResolver;
+
+class IntakeResolverTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// resolve() — all-inherit path falls through to global
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_returns_empty_set_when_global_is_none(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction( 'get_post_meta', array( 'return' => 'inherit' ) );
+		WP_Mock::userFunction(
+			'get_option',
+			array(
+				'return_arg' => 1, // return second arg (default)
+			)
+		);
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertSame( '', $result['set'] );
+		$this->assertFalse( $result['always'] );
+	}
+
+	public function test_resolve_returns_empty_when_post_type_not_found(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => false ) );
+
+		$result = IntakeResolver::resolve( 999 );
+		$this->assertSame( '', $result['set'] );
+		$this->assertFalse( $result['always'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// resolve_set() — tier 1: per-record postmeta
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_returns_set_name_from_postmeta(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		// Postmeta returns a concrete set name.
+		WP_Mock::userFunction(
+			'get_post_meta',
+			array(
+				'return' => function ( $post_id, $key ) {
+					if ( IntakeResolver::META_KEY_SET === $key ) {
+						return 'standard';
+					}
+					return 'inherit'; // always key inherits
+				},
+			)
+		);
+		WP_Mock::userFunction( 'get_option', array( 'return_arg' => 1 ) );
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertSame( 'standard', $result['set'] );
+	}
+
+	public function test_resolve_returns_empty_when_postmeta_is_none(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction(
+			'get_post_meta',
+			array(
+				'return' => function ( $post_id, $key ) {
+					if ( IntakeResolver::META_KEY_SET === $key ) {
+						return 'none';
+					}
+					return '0'; // always = false
+				},
+			)
+		);
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertSame( '', $result['set'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// resolve_set() — tier 2: per-CPT option
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_falls_through_to_cpt_option_when_meta_inherits(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		// Postmeta returns inherit for both keys.
+		WP_Mock::userFunction( 'get_post_meta', array( 'return' => 'inherit' ) );
+		// CPT option returns 'research' for the set key, '' for always.
+		WP_Mock::userFunction(
+			'get_option',
+			array(
+				'return' => function ( $key, $fallback = '' ) {
+					if ( str_contains( $key, 'intake_set_videos' ) ) {
+						return 'research';
+					}
+					return $fallback;
+				},
+			)
+		);
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertSame( 'research', $result['set'] );
+	}
+
+	public function test_resolve_cpt_none_returns_empty_set(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction( 'get_post_meta', array( 'return' => 'inherit' ) );
+		WP_Mock::userFunction(
+			'get_option',
+			array(
+				'return' => function ( $key, $fallback = '' ) {
+					if ( str_contains( $key, 'intake_set_videos' ) ) {
+						return 'none';
+					}
+					return $fallback;
+				},
+			)
+		);
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertSame( '', $result['set'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// resolve_always() — tier 1: per-record postmeta
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_always_true_from_postmeta(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction(
+			'get_post_meta',
+			array(
+				'return' => function ( $post_id, $key ) {
+					if ( IntakeResolver::META_KEY_ALWAYS === $key ) {
+						return '1';
+					}
+					return 'inherit';
+				},
+			)
+		);
+		WP_Mock::userFunction( 'get_option', array( 'return_arg' => 1 ) );
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertTrue( $result['always'] );
+	}
+
+	public function test_resolve_always_false_from_postmeta(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction(
+			'get_post_meta',
+			array(
+				'return' => function ( $post_id, $key ) {
+					if ( IntakeResolver::META_KEY_ALWAYS === $key ) {
+						return '0';
+					}
+					return 'inherit';
+				},
+			)
+		);
+		WP_Mock::userFunction( 'get_option', array( 'return_arg' => 1 ) );
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertFalse( $result['always'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// resolve_always() — tier 3: global option
+	// -------------------------------------------------------------------------
+
+	public function test_resolve_always_true_from_global_option(): void {
+		WP_Mock::userFunction( 'get_post_type', array( 'return' => 'videos' ) );
+		WP_Mock::userFunction( 'get_post_meta', array( 'return' => 'inherit' ) );
+		WP_Mock::userFunction(
+			'get_option',
+			array(
+				'return' => function ( $key, $fallback = '' ) {
+					if ( str_contains( $key, 'intake_always' ) ) {
+						return '1';
+					}
+					return $fallback;
+				},
+			)
+		);
+
+		$result = IntakeResolver::resolve( 1 );
+		$this->assertTrue( $result['always'] );
+	}
+}

--- a/wp-content/plugins/download-gateway/assets/css/gateway-modal.css
+++ b/wp-content/plugins/download-gateway/assets/css/gateway-modal.css
@@ -35,7 +35,8 @@
 	font-family: var(--font-sans);
 }
 
-#gateway-modal-title {
+#gateway-modal-title,
+#gateway-intake-title {
 	font-size: 2em;
 	color: var(--color-black);
 	font-family: var(--font-sans);
@@ -44,30 +45,25 @@
 	margin-bottom: 16px;
 }
 
-#gateway-modal-desc {
+#gateway-modal-desc,
+#gateway-intake-desc {
 	margin: 0 0 1.5rem;
 	color: var(--color-black);
 }
 
-#gateway-form label {
+/* ── Shared container styles ─────────────────────────────────────────── */
+
+.gateway-container label {
 	display: block;
 	font-size: 1.75em;
 	margin: 0.75em 0 0.25em;
 	color: var(--color-black);
 }
 
-#gateway-form label.gateway-consent {
-	display: flex;
-	gap: 0.5em;
-	margin: 2em 0;
-}
-
-#gateway-form label.gateway-consent input[type="checkbox"] {
-	margin: 0;
-}
-
-#gateway-form input[type="text"],
-#gateway-form input[type="email"] {
+.gateway-container input[type="text"],
+.gateway-container input[type="email"],
+.gateway-container select,
+.gateway-container textarea {
 	width: 100%;
 	box-sizing: border-box;
 	padding: 0.6em;
@@ -78,16 +74,64 @@
 	color: var(--color-black);
 }
 
-#gateway-form input:focus {
+.gateway-container input:focus,
+.gateway-container select:focus,
+.gateway-container textarea:focus {
 	outline: none;
 	border-color: var(--color-blue);
 	background-color: var(--color-blue-10);
 }
 
-#gateway-error {
+/* Radio / checkbox groups */
+.gateway-container fieldset {
+	border: none;
+	padding: 0;
+	margin: 0.75em 0 0;
+}
+
+.gateway-container legend {
+	font-size: 1.75em;
+	margin-bottom: 0.25em;
+	color: var(--color-black);
+	font-weight: normal;
+	padding: 0;
+}
+
+.gateway-intake-option {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.5em;
+	margin: 0.4em 0;
+	font-size: 1.75em;
+	color: var(--color-black);
+	cursor: pointer;
+}
+
+.gateway-intake-option input {
+	margin-top: 0.2em;
+	flex-shrink: 0;
+}
+
+/* Error messages */
+#gateway-error,
+#gateway-intake-error {
 	margin: 0.75em 0 0;
 	color: #c00;
 }
+
+/* ── Gate-specific ───────────────────────────────────────────────────── */
+
+.gateway-container.gate label.gateway-consent {
+	display: flex;
+	gap: 0.5em;
+	margin: 2em 0;
+}
+
+.gateway-container.gate label.gateway-consent input[type="checkbox"] {
+	margin: 0;
+}
+
+/* ── Actions ─────────────────────────────────────────────────────────── */
 
 .gateway-actions {
 	display: flex;
@@ -95,7 +139,8 @@
 	margin-top: 1em;
 }
 
-#gateway-submit {
+#gateway-submit,
+#gateway-intake-submit {
 	padding: 1em;
 	background: var(--color-blue);
 	color: var(--color-parchment);
@@ -104,12 +149,14 @@
 	cursor: pointer;
 }
 
-#gateway-submit:disabled {
+#gateway-submit:disabled,
+#gateway-intake-submit:disabled {
 	opacity: 0.6;
 	cursor: not-allowed;
 }
 
-#gateway-skip {
+#gateway-skip,
+#gateway-intake-skip {
 	background: none;
 	border: none;
 	color: var(--color-blue);
@@ -122,7 +169,9 @@
 	border-radius: 4px;
 	margin-top: 4px;
 }
-#gateway-skip:hover {
+
+#gateway-skip:hover,
+#gateway-intake-skip:hover {
 	background: #e1d9e4;
 	mix-blend-mode: darken;
 }
@@ -147,7 +196,8 @@
 	mix-blend-mode: darken;
 }
 
-/* Loading step */
+/* ── Loading step ────────────────────────────────────────────────────── */
+
 #gateway-loading-container {
 	text-align: center;
 	padding: 1.5em 0;

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -3,7 +3,7 @@
 	'use strict';
 
 	// gatewaySettings is localized by PHP:
-	//   { nonce, restNonce, apiUrl, downloadBase, intakeUrl, intakeSteps }
+	//   { nonce, restNonce, apiUrl, downloadBase, intakeUrl, intakeSets }
 	if ( typeof gatewaySettings === 'undefined' ) {
 		return;
 	}
@@ -68,7 +68,7 @@
 			// ── Step 1: gate form ──────────────────────────────────────────
 			'<div id="gateway-gate-container">' +
 			'<h2 id="gateway-modal-title">Download and support the archive</h2>' +
-			'<p id="gateway-modal-desc">This material is part of a global effort to preserve and share human language<br/><br/>Add your name to support the archive and receive updates on new languages, stories, and tools.</p>' +
+			'<p id="gateway-modal-desc">This material is part of a global effort to preserve and share human language.<br/><br/>Add your name to support the archive and receive updates on new languages, stories, and tools.</p>' +
 			'<form id="gateway-form" novalidate>' +
 				'<label for="gateway-name">Name<span aria-hidden="true">*</span></label>' +
 				'<input id="gateway-name" name="name" type="text" autocomplete="name" required />' +
@@ -140,6 +140,8 @@
 	var currentPostType    = null;
 	var currentDirectUrl   = null;
 	var currentIsExternal  = false;
+	var currentIntakeSet   = '';
+	var currentIntakeAlways = false;
 
 	// Pending state — populated when gate passes and intake step is active.
 	var pendingToken          = null;
@@ -149,16 +151,18 @@
 	var pendingDirectUrl      = null;
 	var pendingIsExternal     = false;
 
-	function openModal( postId, policy, directUrl, postType, isExternal ) {
+	function openModal( postId, policy, directUrl, postType, isExternal, intakeSet, intakeAlways ) {
 		if ( ! modal ) {
 			buildModal();
 			attachModalEvents();
 		}
 
-		currentPostId     = postId;
-		currentPostType   = postType || '';
-		currentDirectUrl  = directUrl;
-		currentIsExternal = !! isExternal;
+		currentPostId       = postId;
+		currentPostType     = postType || '';
+		currentDirectUrl    = directUrl;
+		currentIsExternal   = !! isExternal;
+		currentIntakeSet    = intakeSet    || '';
+		currentIntakeAlways = !! intakeAlways;
 
 		// Reset to gate step.
 		errorMsg.textContent           = '';
@@ -181,10 +185,12 @@
 		if ( overlay ) {
 			overlay.classList.remove( 'is-open' );
 		}
-		currentPostId     = null;
-		currentPostType   = null;
-		currentDirectUrl  = null;
-		currentIsExternal = false;
+		currentPostId       = null;
+		currentPostType     = null;
+		currentDirectUrl    = null;
+		currentIsExternal   = false;
+		currentIntakeSet    = '';
+		currentIntakeAlways = false;
 		clearPending();
 	}
 
@@ -303,7 +309,7 @@
 					showError( result.data.message || 'Something went wrong. Please try again.' );
 					return;
 				}
-				setCookie( 'gateway_gated', result.data.person_cookie, 30 );
+				setCookie( 'gateway_gated', result.data.person_cookie, 0 );
 				proceedAfterGate(
 					result.data.token,
 					result.data.person_cookie,
@@ -352,16 +358,17 @@
 	 * filter, show step 2. Otherwise download immediately.
 	 */
 	function proceedAfterGate( token, personCookie, postId, postType, directUrl, isExternal ) {
-		var steps = gatewaySettings.intakeSteps &&
-		            gatewaySettings.intakeSteps[ postType ];
-		if ( token && steps && steps.length ) {
+		var fields = currentIntakeSet &&
+		             gatewaySettings.intakeSets &&
+		             gatewaySettings.intakeSets[ currentIntakeSet ];
+		if ( token && fields && fields.length ) {
 			pendingToken        = token;
 			pendingPersonCookie = personCookie;
 			pendingPostId       = postId;
 			pendingPostType     = postType;
 			pendingDirectUrl    = directUrl;
 			pendingIsExternal   = !! isExternal;
-			showIntakeStep( steps );
+			showIntakeStep( fields );
 		} else if ( token ) {
 			proceedToDownload( token, directUrl, isExternal );
 		} else {
@@ -521,7 +528,7 @@
 	 * Falls back to the modal if the server rejects the passthrough
 	 * (e.g. person was anonymized).
 	 */
-	function doSilentPassthrough( postId, policy, personCookie, directUrl, postType, isExternal ) {
+	function doSilentPassthrough( postId, policy, personCookie, directUrl, postType, isExternal, intakeSet, intakeAlways ) {
 		var body = new URLSearchParams( {
 			post_id:      postId,
 			_passthrough: personCookie,
@@ -542,15 +549,45 @@
 			.then( function ( result ) {
 				if ( ! result.ok ) {
 					// Passthrough rejected — show gate form.
-					openModal( postId, policy, directUrl, postType, isExternal );
+					openModal( postId, policy, directUrl, postType, isExternal, intakeSet, intakeAlways );
 					return;
 				}
-				setCookie( 'gateway_gated', result.data.person_cookie, 30 );
-				proceedToDownload( result.data.token, directUrl, isExternal );
+				setCookie( 'gateway_gated', result.data.person_cookie, 0 );
+
+				// If intakeAlways is set and a field set is configured, show intake
+				// step even for passthrough (repeat) downloads.
+				var fields = intakeAlways && intakeSet &&
+				             gatewaySettings.intakeSets &&
+				             gatewaySettings.intakeSets[ intakeSet ];
+				if ( fields && fields.length && ! isExternal ) {
+					if ( ! modal ) {
+						buildModal();
+						attachModalEvents();
+					}
+					currentPostId       = postId;
+					currentPostType     = postType || '';
+					currentDirectUrl    = directUrl;
+					currentIsExternal   = false;
+					currentIntakeSet    = intakeSet;
+					currentIntakeAlways = true;
+					pendingToken        = result.data.token;
+					pendingPersonCookie = result.data.person_cookie;
+					pendingPostId       = postId;
+					pendingPostType     = postType;
+					pendingDirectUrl    = directUrl;
+					pendingIsExternal   = false;
+					errorMsg.textContent           = '';
+					gateContainer.style.display    = 'none';
+					loadingContainer.style.display = 'none';
+					overlay.classList.add( 'is-open' );
+					showIntakeStep( gatewaySettings.intakeSets[ intakeSet ] );
+				} else {
+					proceedToDownload( result.data.token, directUrl, isExternal );
+				}
 			} )
 			.catch( function () {
 				// Network error — fall back to modal.
-				openModal( postId, policy, directUrl, postType, isExternal );
+				openModal( postId, policy, directUrl, postType, isExternal, intakeSet, intakeAlways );
 			} );
 	}
 
@@ -570,11 +607,13 @@
 
 		var isExternal   = !! link.dataset.fileUrl;
 		var directUrl    = link.dataset.fileUrl || link.href;
+		var intakeSet    = link.dataset.intakeSet    || '';
+		var intakeAlways = link.dataset.intakeAlways === '1';
 		var personCookie = getCookie( 'gateway_gated' );
 		if ( personCookie ) {
-			doSilentPassthrough( link.dataset.postId, policy, personCookie, directUrl, link.dataset.postType, isExternal );
+			doSilentPassthrough( link.dataset.postId, policy, personCookie, directUrl, link.dataset.postType, isExternal, intakeSet, intakeAlways );
 		} else {
-			openModal( link.dataset.postId, policy, directUrl, link.dataset.postType, isExternal );
+			openModal( link.dataset.postId, policy, directUrl, link.dataset.postType, isExternal, intakeSet, intakeAlways );
 		}
 	} );
 }() );

--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -66,7 +66,7 @@
 			'<button id="gateway-close" aria-label="Close">&times;</button>' +
 
 			// ── Step 1: gate form ──────────────────────────────────────────
-			'<div id="gateway-gate-container">' +
+			'<div id="gateway-gate-container" class="gateway-container gate">' +
 			'<h2 id="gateway-modal-title">Download and support the archive</h2>' +
 			'<p id="gateway-modal-desc">This material is part of a global effort to preserve and share human language.<br/><br/>Add your name to support the archive and receive updates on new languages, stories, and tools.</p>' +
 			'<form id="gateway-form" novalidate>' +
@@ -91,7 +91,7 @@
 			'</div>' +
 
 			// ── Step 2: intake form (hidden until gate passes) ─────────────
-			'<div id="gateway-intake-container" style="display:none">' +
+			'<div id="gateway-intake-container" class="gateway-container intake" style="display:none">' +
 			'<h2 id="gateway-intake-title">One more thing</h2>' +
 			'<p id="gateway-intake-desc">Help us understand how you\'ll use this resource. This is optional.</p>' +
 			'<form id="gateway-intake-form" novalidate></form>' +

--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GATEWAY_VERSION', '0.1.10' );
+define( 'GATEWAY_VERSION', '0.1.11' );
 define( 'GATEWAY_FILE', __FILE__ );
 define( 'GATEWAY_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GATEWAY_REST_NAMESPACE', 'gateway/v1' );
@@ -56,6 +56,7 @@ require_once GATEWAY_DIR . 'includes/class-person-cookie.php';
 require_once GATEWAY_DIR . 'includes/class-gate-controller.php';
 require_once GATEWAY_DIR . 'includes/class-intake-repository.php';
 require_once GATEWAY_DIR . 'includes/class-intake-controller.php';
+require_once GATEWAY_DIR . 'includes/class-intake-resolver.php';
 require_once GATEWAY_DIR . 'includes/class-retention-job.php';
 require_once GATEWAY_DIR . 'includes/admin/class-settings-page.php';
 
@@ -115,10 +116,10 @@ add_action(
 			true
 		);
 		/**
-		 * Filters intake field definitions for the download modal step 2.
+		 * Filters named intake field set definitions for the download modal step 2.
 		 *
-		 * Return an array keyed by post type slug. Each value is an array of
-		 * field definition arrays with keys:
+		 * Return an array keyed by set name. Each value is an array of field
+		 * definition arrays with keys:
 		 *   key      — machine name (used as the response key in the DB)
 		 *   label    — human-readable label
 		 *   type     — text | textarea | select | radio | checkbox
@@ -126,15 +127,15 @@ add_action(
 		 *   required — bool (currently informational; JS does not enforce)
 		 *
 		 * Example:
-		 *   add_filter( 'gateway_intake_fields', function( $fields ) {
-		 *       $fields['document_files'] = array(
+		 *   add_filter( 'gateway_intake_fields', function( $sets ) {
+		 *       $sets['standard'] = array(
 		 *           array( 'key' => 'use_case', 'label' => 'How will you use this?',
 		 *                  'type' => 'select', 'options' => array( 'research' => 'Research' ) ),
 		 *       );
-		 *       return $fields;
+		 *       return $sets;
 		 *   } );
 		 *
-		 * @param array<string,array<int,array<string,mixed>>> $fields Empty by default.
+		 * @param array<string,array<int,array<string,mixed>>> $sets Empty by default.
 		 */
 		wp_localize_script(
 			'gateway-modal',
@@ -145,7 +146,7 @@ add_action(
 				'apiUrl'       => rest_url( GATEWAY_REST_NAMESPACE . '/gate' ),
 				'downloadBase' => rest_url( GATEWAY_REST_NAMESPACE . '/download' ),
 				'intakeUrl'    => rest_url( GATEWAY_REST_NAMESPACE . '/intake' ),
-				'intakeSteps'  => (array) apply_filters( 'gateway_intake_fields', array() ),
+				'intakeSets'   => (array) apply_filters( 'gateway_intake_fields', array() ),
 			)
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -73,6 +73,44 @@ class Settings_Page {
 		}
 
 		update_option( SettingsRepository::OPTION_RETENTION_MONTHS, $retention_months );
+
+		// Intake — global set.
+		/** This filter is documented in download-gateway.php. */
+		$registered_sets    = array_keys( (array) apply_filters( 'gateway_intake_fields', array() ) );
+		$allowed_set_values = array_merge( array( 'none' ), $registered_sets );
+
+		$global_intake_set = isset( $_POST[ SettingsRepository::OPTION_GLOBAL_INTAKE_SET ] )
+			? sanitize_key( $_POST[ SettingsRepository::OPTION_GLOBAL_INTAKE_SET ] )
+			: 'none';
+		if ( ! in_array( $global_intake_set, $allowed_set_values, true ) ) {
+			$global_intake_set = 'none';
+		}
+		update_option( SettingsRepository::OPTION_GLOBAL_INTAKE_SET, $global_intake_set );
+
+		// Intake — global always.
+		$global_intake_always = ! empty( $_POST[ SettingsRepository::OPTION_GLOBAL_INTAKE_ALWAYS ] ) ? '1' : '0';
+		update_option( SettingsRepository::OPTION_GLOBAL_INTAKE_ALWAYS, $global_intake_always );
+
+		// Intake — per-CPT set and always.
+		foreach ( $post_types as $post_type ) {
+			$set_key   = SettingsRepository::OPTION_CPT_INTAKE_SET_PREFIX . $post_type;
+			$set_value = isset( $_POST[ $set_key ] ) ? sanitize_key( $_POST[ $set_key ] ) : '';
+			// Empty = inherit (delete option); otherwise validate against allowed.
+			if ( '' !== $set_value && ! in_array( $set_value, $allowed_set_values, true ) ) {
+				$set_value = '';
+			}
+			SettingsRepository::update_cpt_intake_set( $post_type, $set_value );
+
+			$always_key   = SettingsRepository::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type;
+			$always_value = isset( $_POST[ $always_key ] ) ? sanitize_key( $_POST[ $always_key ] ) : '';
+			if ( '1' === $always_value ) {
+				SettingsRepository::update_cpt_intake_always( $post_type, true );
+			} elseif ( '0' === $always_value ) {
+				SettingsRepository::update_cpt_intake_always( $post_type, false );
+			} else {
+				SettingsRepository::update_cpt_intake_always( $post_type, null );
+			}
+		}
 	}
 
 	/**
@@ -159,6 +197,30 @@ class Settings_Page {
 		return $labels[ $policy ] ?? esc_html( $policy );
 	}
 
+	/** Render a <select> for an intake set field. */
+	private static function intake_set_select( string $name, string $current, array $registered_sets, bool $include_inherit = true ): void {
+		echo '<select name="' . esc_attr( $name ) . '">';
+		if ( $include_inherit ) {
+			echo '<option value="" ' . selected( $current, '', false ) . '>Inherit</option>';
+		}
+		echo '<option value="none" ' . selected( $current, 'none', false ) . '>None — no intake form</option>';
+		foreach ( $registered_sets as $set_name ) {
+			echo '<option value="' . esc_attr( $set_name ) . '" ' . selected( $current, $set_name, false ) . '>' . esc_html( $set_name ) . '</option>';
+		}
+		echo '</select>';
+	}
+
+	/** Render a <select> for the intake always-show field. */
+	private static function intake_always_select( string $name, string $current, bool $include_inherit = true ): void {
+		echo '<select name="' . esc_attr( $name ) . '">';
+		if ( $include_inherit ) {
+			echo '<option value="" ' . selected( $current, '', false ) . '>Inherit</option>';
+		}
+		echo '<option value="0" ' . selected( $current, '0', false ) . '>No — first download only</option>';
+		echo '<option value="1" ' . selected( $current, '1', false ) . '>Yes — every session</option>';
+		echo '</select>';
+	}
+
 	/** Render a <select> for a policy field. */
 	private static function policy_select( string $name, string $current, bool $include_inherit = true ): void {
 		echo '<select name="' . esc_attr( $name ) . '">';
@@ -184,7 +246,11 @@ class Settings_Page {
 
 		$current_policy           = SettingsRepository::get_global_gate_policy();
 		$current_retention_months = SettingsRepository::get_retention_months();
-		$last_run                 = get_option( RetentionJob::OPTION_LAST_RUN, null );
+		/** This filter is documented in download-gateway.php. */
+		$registered_sets       = array_keys( (array) apply_filters( 'gateway_intake_fields', array() ) );
+		$current_intake_set    = SettingsRepository::get_global_intake_set();
+		$current_intake_always = SettingsRepository::get_global_intake_always() ? '1' : '0';
+		$last_run              = get_option( RetentionJob::OPTION_LAST_RUN, null );
 		/**
 		 * Filters the post types shown in the per-CPT policy settings table.
 		 *
@@ -253,10 +319,56 @@ class Settings_Page {
 						</td>
 					</tr>
 					<?php endforeach; ?>
+				</table>
 
+				<h2 class="title">Intake forms</h2>
+				<p>
+					Intake forms are an optional step 2 shown after the gate, collecting supplementary information.
+					Field sets are registered via the <code>gateway_intake_fields</code> PHP filter.
+					<?php if ( empty( $registered_sets ) ) : ?>
+					<br /><em>No intake field sets are currently registered.</em>
+					<?php endif; ?>
+				</p>
+
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row">Global default set</th>
+						<td>
+							<?php self::intake_set_select( SettingsRepository::OPTION_GLOBAL_INTAKE_SET, $current_intake_set, $registered_sets, false ); ?>
+							<p class="description">Fallback intake set when no per-CPT or per-resource override is set.</p>
+						</td>
+					</tr>
+					<tr>
+						<th scope="row">Show on repeat downloads (global)</th>
+						<td>
+							<?php self::intake_always_select( SettingsRepository::OPTION_GLOBAL_INTAKE_ALWAYS, $current_intake_always, false ); ?>
+							<p class="description">When set to "Yes", the intake form also appears for returning visitors downloading again within the same session.</p>
+						</td>
+					</tr>
+
+					<?php foreach ( $post_types as $post_type ) : ?>
+						<?php
+						$cpt_intake_set    = SettingsRepository::get_cpt_intake_set( $post_type ) ?? '';
+						$cpt_intake_always = SettingsRepository::get_cpt_intake_always( $post_type );
+						$cpt_always_value  = null === $cpt_intake_always ? '' : ( $cpt_intake_always ? '1' : '0' );
+						?>
+					<tr>
+						<th scope="row"><?php echo esc_html( $post_type ); ?></th>
+						<td>
+							<?php self::intake_set_select( SettingsRepository::OPTION_CPT_INTAKE_SET_PREFIX . $post_type, $cpt_intake_set, $registered_sets ); ?>
+							&nbsp;
+							<?php self::intake_always_select( SettingsRepository::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type, $cpt_always_value ); ?>
+							<p class="description">Set &nbsp;/&nbsp; Always show</p>
+						</td>
+					</tr>
+					<?php endforeach; ?>
+				</table>
+
+				<h2 class="title">Data retention</h2>
+				<table class="form-table" role="presentation">
 					<tr>
 						<th scope="row">
-							<label for="gateway_retention_months">Data retention</label>
+							<label for="gateway_retention_months">Retention window</label>
 						</th>
 						<td>
 							<input

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -52,13 +52,16 @@ class Download_Shortcode {
 
 		$url       = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
 		$post_type = get_post_type( $post_id ) ?: '';
+		$intake    = IntakeResolver::resolve( $post_id );
 
 		return sprintf(
-			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s" data-post-type="%s">%s</a>',
+			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s" data-post-type="%s" data-intake-set="%s" data-intake-always="%s">%s</a>',
 			esc_url( $url ),
 			$post_id,
 			esc_attr( $policy ),
 			esc_attr( $post_type ),
+			esc_attr( $intake['set'] ),
+			$intake['always'] ? '1' : '0',
 			esc_html( $atts['label'] )
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/class-intake-resolver.php
+++ b/wp-content/plugins/download-gateway/includes/class-intake-resolver.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * IntakeResolver — 3-tier resolution of intake form set and always-show flag.
+ *
+ * Follows the same pattern as PolicyResolver:
+ *   per-record postmeta → per-CPT wp_option → global wp_option
+ *
+ * Returns an array:
+ *   'set'    — named set key registered via gateway_intake_fields filter,
+ *              or empty string meaning no intake form.
+ *   'always' — bool; when true, intake shows on passthrough (repeat downloads
+ *              within the same browser session) as well as first-time gate.
+ *
+ * @package WT\DownloadGateway
+ */
+
+namespace WT\DownloadGateway;
+
+class IntakeResolver {
+
+	/** Postmeta key for per-resource intake set override. */
+	const META_KEY_SET = '_gateway_intake_set';
+
+	/** Postmeta key for per-resource always-show override. */
+	const META_KEY_ALWAYS = '_gateway_intake_always';
+
+	/**
+	 * Resolve intake configuration for a given post.
+	 *
+	 * @param int $post_id Post ID of the downloadable resource.
+	 * @return array{ set: string, always: bool }
+	 */
+	public static function resolve( int $post_id ): array {
+		$post_type = get_post_type( $post_id );
+		if ( ! $post_type ) {
+			return array(
+				'set'    => '',
+				'always' => false,
+			);
+		}
+
+		return array(
+			'set'    => self::resolve_set( $post_id, $post_type ),
+			'always' => self::resolve_always( $post_id, $post_type ),
+		);
+	}
+
+	/**
+	 * Resolve the intake field set name for a post.
+	 *
+	 * Returns the set name string, or empty string if no intake should be shown.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $post_type Post type slug.
+	 * @return string
+	 */
+	private static function resolve_set( int $post_id, string $post_type ): string {
+		// Tier 1: per-resource postmeta.
+		$meta = (string) get_post_meta( $post_id, self::META_KEY_SET, true );
+		if ( 'none' === $meta ) {
+			return '';
+		}
+		if ( '' !== $meta && 'inherit' !== $meta ) {
+			return $meta;
+		}
+
+		// Tier 2: per-CPT option.
+		$cpt = SettingsRepository::get_cpt_intake_set( $post_type );
+		if ( null !== $cpt ) {
+			return 'none' === $cpt ? '' : $cpt;
+		}
+
+		// Tier 3: global option.
+		$global = SettingsRepository::get_global_intake_set();
+		return 'none' === $global ? '' : $global;
+	}
+
+	/**
+	 * Resolve the always-show flag for a post.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $post_type Post type slug.
+	 * @return bool
+	 */
+	private static function resolve_always( int $post_id, string $post_type ): bool {
+		// Tier 1: per-resource postmeta.
+		$meta = (string) get_post_meta( $post_id, self::META_KEY_ALWAYS, true );
+		if ( '1' === $meta ) {
+			return true;
+		}
+		if ( '0' === $meta ) {
+			return false;
+		}
+		// '' or 'inherit' → fall through.
+
+		// Tier 2: per-CPT option.
+		$cpt = SettingsRepository::get_cpt_intake_always( $post_type );
+		if ( null !== $cpt ) {
+			return $cpt;
+		}
+
+		// Tier 3: global option.
+		return SettingsRepository::get_global_intake_always();
+	}
+}

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -58,13 +58,34 @@ class Resource_Metabox {
 		}
 
 		update_post_meta( $post_id, '_gateway_gate_policy', $value );
+
+		// Intake set — free-form set name, 'none', 'inherit', or empty.
+		$intake_set = isset( $_POST['_gateway_intake_set'] )
+			? sanitize_key( $_POST['_gateway_intake_set'] )
+			: 'inherit';
+		update_post_meta( $post_id, IntakeResolver::META_KEY_SET, $intake_set );
+
+		// Intake always — '1', '0', or 'inherit'.
+		$intake_always_allowed = array( '1', '0', 'inherit' );
+		$intake_always         = isset( $_POST['_gateway_intake_always'] )
+			? sanitize_key( $_POST['_gateway_intake_always'] )
+			: 'inherit';
+		if ( ! in_array( $intake_always, $intake_always_allowed, true ) ) {
+			$intake_always = 'inherit';
+		}
+		update_post_meta( $post_id, IntakeResolver::META_KEY_ALWAYS, $intake_always );
 	}
 
 	public static function render( \WP_Post $post ): void {
 		wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD );
 
-		$policy = (string) get_post_meta( $post->ID, '_gateway_gate_policy', true );
-		$url    = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post->ID );
+		$policy        = (string) get_post_meta( $post->ID, '_gateway_gate_policy', true );
+		$intake_set    = (string) get_post_meta( $post->ID, IntakeResolver::META_KEY_SET, true );
+		$intake_always = (string) get_post_meta( $post->ID, IntakeResolver::META_KEY_ALWAYS, true );
+		$url           = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post->ID );
+
+		/** This filter is documented in download-gateway.php. */
+		$registered_sets = array_keys( (array) apply_filters( 'gateway_intake_fields', array() ) );
 		?>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Gate policy</p>
 		<select name="_gateway_gate_policy" style="width:100%;margin-bottom:10px;">
@@ -73,6 +94,20 @@ class Resource_Metabox {
 			<option value="soft"     <?php selected( $policy, 'soft' ); ?>>Soft gate — skippable prompt</option>
 			<option value="hard"     <?php selected( $policy, 'hard' ); ?>>Hard gate — email required</option>
 			<option value="disabled" <?php selected( $policy, 'disabled' ); ?>>Disabled — hide download link</option>
+		</select>
+		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Intake form</p>
+		<select name="_gateway_intake_set" style="width:100%;margin-bottom:6px;">
+			<option value="inherit" <?php selected( $intake_set, 'inherit' ); ?>>Inherit (use CPT / global default)</option>
+			<option value="none"    <?php selected( $intake_set, 'none' ); ?>>None — no intake form</option>
+			<?php foreach ( $registered_sets as $set_name ) : ?>
+			<option value="<?php echo esc_attr( $set_name ); ?>" <?php selected( $intake_set, $set_name ); ?>><?php echo esc_html( $set_name ); ?></option>
+			<?php endforeach; ?>
+		</select>
+		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Show intake on repeat downloads</p>
+		<select name="_gateway_intake_always" style="width:100%;margin-bottom:10px;">
+			<option value="inherit" <?php selected( $intake_always, 'inherit' ); ?>>Inherit (use CPT / global default)</option>
+			<option value="0"       <?php selected( $intake_always, '0' ); ?>>No — first download only</option>
+			<option value="1"       <?php selected( $intake_always, '1' ); ?>>Yes — every session</option>
 		</select>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Download URL</p>
 		<input

--- a/wp-content/plugins/download-gateway/includes/class-settings-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-settings-repository.php
@@ -14,11 +14,15 @@ namespace WT\DownloadGateway;
 class SettingsRepository {
 
 	// Option keys.
-	const OPTION_GLOBAL_GATE_POLICY = 'gateway_global_gate_policy';
-	const OPTION_RETENTION_MONTHS   = 'gateway_retention_months';
+	const OPTION_GLOBAL_GATE_POLICY   = 'gateway_global_gate_policy';
+	const OPTION_RETENTION_MONTHS     = 'gateway_retention_months';
+	const OPTION_GLOBAL_INTAKE_SET    = 'gateway_global_intake_set';
+	const OPTION_GLOBAL_INTAKE_ALWAYS = 'gateway_global_intake_always';
 
 	/** Option key pattern for per-CPT policy. Sprintf with post_type. */
-	const OPTION_CPT_POLICY_PREFIX = 'gateway_cpt_policy_';
+	const OPTION_CPT_POLICY_PREFIX        = 'gateway_cpt_policy_';
+	const OPTION_CPT_INTAKE_SET_PREFIX    = 'gateway_cpt_intake_set_';
+	const OPTION_CPT_INTAKE_ALWAYS_PREFIX = 'gateway_cpt_intake_always_';
 
 	// Valid gate policy values (concrete — used as effective resolved values).
 	const POLICY_NONE     = 'none';
@@ -88,6 +92,79 @@ class SettingsRepository {
 			update_option( self::OPTION_CPT_POLICY_PREFIX . $post_type, $policy );
 		} else {
 			delete_option( self::OPTION_CPT_POLICY_PREFIX . $post_type );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Intake form settings.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns the site-wide default intake field set name, or 'none'.
+	 */
+	public static function get_global_intake_set(): string {
+		return (string) get_option( self::OPTION_GLOBAL_INTAKE_SET, 'none' );
+	}
+
+	/**
+	 * Returns the per-CPT intake field set name, or null if not set (inherit).
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @return string|null Set name / 'none', or null to inherit.
+	 */
+	public static function get_cpt_intake_set( string $post_type ): ?string {
+		$value = get_option( self::OPTION_CPT_INTAKE_SET_PREFIX . $post_type, '' );
+		return '' !== $value ? (string) $value : null;
+	}
+
+	/**
+	 * Persist a per-CPT intake set override.
+	 * Pass empty string to delete the override and inherit from global.
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @param string $set_name  Set name, 'none', or '' to clear.
+	 */
+	public static function update_cpt_intake_set( string $post_type, string $set_name ): void {
+		if ( '' === $set_name ) {
+			delete_option( self::OPTION_CPT_INTAKE_SET_PREFIX . $post_type );
+		} else {
+			update_option( self::OPTION_CPT_INTAKE_SET_PREFIX . $post_type, $set_name );
+		}
+	}
+
+	/**
+	 * Returns the site-wide always-show-on-passthrough flag.
+	 */
+	public static function get_global_intake_always(): bool {
+		return '1' === (string) get_option( self::OPTION_GLOBAL_INTAKE_ALWAYS, '0' );
+	}
+
+	/**
+	 * Returns the per-CPT always-show flag, or null if not set (inherit).
+	 *
+	 * @param string $post_type WordPress post type slug.
+	 * @return bool|null
+	 */
+	public static function get_cpt_intake_always( string $post_type ): ?bool {
+		$value = get_option( self::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type, '' );
+		if ( '' === $value ) {
+			return null;
+		}
+		return '1' === (string) $value;
+	}
+
+	/**
+	 * Persist a per-CPT always-show override.
+	 * Pass null to delete the override and inherit from global.
+	 *
+	 * @param string    $post_type WordPress post type slug.
+	 * @param bool|null $always    True, false, or null to clear.
+	 */
+	public static function update_cpt_intake_always( string $post_type, ?bool $always ): void {
+		if ( null === $always ) {
+			delete_option( self::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type );
+		} else {
+			update_option( self::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type, $always ? '1' : '0' );
 		}
 	}
 

--- a/wp-content/themes/blankslate-child/functions.php
+++ b/wp-content/themes/blankslate-child/functions.php
@@ -5,3 +5,8 @@ foreach ( $includes_dirs as $dir ) {
 		require_once $file;
 	}
 }
+
+// Module-level hook registrations (e.g. intake field sets).
+foreach ( glob( __DIR__ . '/modules/*/intake.php' ) as $file ) {
+	require_once $file;
+}

--- a/wp-content/themes/blankslate-child/modules/captions/intake.php
+++ b/wp-content/themes/blankslate-child/modules/captions/intake.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Intake field set: captions
+ *
+ * Registered as the 'captions' named set for the gateway_intake_fields filter.
+ * Assign this set to the captions CPT via Gateway > Settings > Intake forms.
+ */
+
+add_filter(
+	'gateway_intake_fields',
+	function ( array $sets ): array {
+		$sets['captions'] = array(
+			array(
+				'key'     => 'use_case',
+				'label'   => 'How will you use this resource?',
+				'type'    => 'select',
+				'options' => array(
+					'research'    => 'Personal or academic research',
+					'teaching'    => 'Teaching or curriculum development',
+					'documentary' => 'Documentary or journalism',
+					'advocacy'    => 'Advocacy or policy work',
+					'personal'    => 'Personal interest',
+					'other'       => 'Other',
+				),
+			),
+			array(
+				'key'     => 'community',
+				'label'   => 'Are you a member of the Wikitongues community?',
+				'type'    => 'radio',
+				'options' => array(
+					'speaker'      => 'Yes — I\'m a speaker or learner of this language',
+					'contributor'  => 'Yes — I contribute to Wikitongues',
+					'discovering'  => 'No — I\'m discovering endangered languages',
+					'professional' => 'No — I work with language data professionally',
+				),
+			),
+		);
+		return $sets;
+	}
+);

--- a/wp-content/themes/blankslate-child/modules/documents/intake.php
+++ b/wp-content/themes/blankslate-child/modules/documents/intake.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Intake field set: documents
+ *
+ * Registered as the 'documents' named set for the gateway_intake_fields filter.
+ * Assign this set to the documents CPT via Gateway > Settings > Intake forms.
+ */
+
+add_filter(
+	'gateway_intake_fields',
+	function ( array $sets ): array {
+		$sets['documents'] = array(
+			array(
+				'key'     => 'use_case',
+				'label'   => 'How will you use this resource?',
+				'type'    => 'select',
+				'options' => array(
+					'research'      => 'Personal or academic research',
+					'teaching'      => 'Teaching or curriculum development',
+					'advocacy'      => 'Advocacy or policy work',
+					'grant_writing' => 'Grant writing or institutional reporting',
+					'personal'      => 'Personal interest',
+					'other'         => 'Other',
+				),
+			),
+			array(
+				'key'   => 'organization',
+				'label' => 'Are you affiliated with an organization? (optional)',
+				'type'  => 'text',
+			),
+			array(
+				'key'     => 'community',
+				'label'   => 'Are you a member of the Wikitongues community?',
+				'type'    => 'radio',
+				'options' => array(
+					'speaker'      => 'Yes — I\'m a speaker or learner of this language',
+					'contributor'  => 'Yes — I contribute to Wikitongues',
+					'discovering'  => 'No — I\'m discovering endangered languages',
+					'professional' => 'No — I work with language data professionally',
+				),
+			),
+		);
+		return $sets;
+	}
+);

--- a/wp-content/themes/blankslate-child/modules/videos/intake.php
+++ b/wp-content/themes/blankslate-child/modules/videos/intake.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Intake field set: videos
+ *
+ * Registered as the 'videos' named set for the gateway_intake_fields filter.
+ * Assign this set to the videos CPT via Gateway > Settings > Intake forms.
+ */
+
+add_filter(
+	'gateway_intake_fields',
+	function ( array $sets ): array {
+		$sets['videos'] = array(
+			array(
+				'key'     => 'use_case',
+				'label'   => 'How will you use this resource?',
+				'type'    => 'select',
+				'options' => array(
+					'research'    => 'Personal or academic research',
+					'teaching'    => 'Teaching or curriculum development',
+					'documentary' => 'Documentary or journalism',
+					'advocacy'    => 'Advocacy or policy work',
+					'personal'    => 'Personal interest',
+					'other'       => 'Other',
+				),
+			),
+			array(
+				'key'     => 'community',
+				'label'   => 'Are you a member of the Wikitongues community?',
+				'type'    => 'radio',
+				'options' => array(
+					'speaker'      => 'Yes — I\'m a speaker or learner of this language',
+					'contributor'  => 'Yes — I contribute to Wikitongues',
+					'discovering'  => 'No — I\'m discovering endangered languages',
+					'professional' => 'No — I work with language data professionally',
+				),
+			),
+		);
+		return $sets;
+	}
+);

--- a/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+++ b/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
@@ -56,11 +56,14 @@
 					$caption_policy   = \WT\DownloadGateway\PolicyResolver::resolve( $caption->ID );
 					$caption_disabled = ( $caption_policy === \WT\DownloadGateway\SettingsRepository::POLICY_DISABLED );
 					if ( ! $caption_disabled ) {
+						$caption_intake = \WT\DownloadGateway\IntakeResolver::resolve( $caption->ID );
 						$caption_dl_url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $caption->ID );
 						$caption_items .= '<li><a href="' . esc_url( $caption_dl_url ) . '" class="gateway-download-link"'
 							. ' data-post-id="' . esc_attr( (string) $caption->ID ) . '"'
 							. ' data-policy="' . esc_attr( $caption_policy ) . '"'
-							. ' data-post-type="captions">'
+							. ' data-post-type="captions"'
+							. ' data-intake-set="' . esc_attr( $caption_intake['set'] ) . '"'
+							. ' data-intake-always="' . ( $caption_intake['always'] ? '1' : '0' ) . '">'
 							. esc_html( $label ) . ' (.srt)</a></li>';
 					}
 				} else {
@@ -98,11 +101,14 @@
 				if ( $has_dropbox ) {
 					if ( $gateway_active ) {
 						if ( ! $video_disabled ) {
+							$video_intake = \WT\DownloadGateway\IntakeResolver::resolve( $video_id );
 							$video_dl_url = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $video_id );
 							echo '<li><a href="' . esc_url( $video_dl_url ) . '" class="gateway-download-link"'
 								. ' data-post-id="' . esc_attr( (string) $video_id ) . '"'
 								. ' data-policy="' . esc_attr( $video_policy ) . '"'
-								. ' data-post-type="videos">Dropbox (.mp4)</a></li>';
+								. ' data-post-type="videos"'
+								. ' data-intake-set="' . esc_attr( $video_intake['set'] ) . '"'
+								. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '">Dropbox (.mp4)</a></li>';
 						}
 					} else {
 						echo '<li><a href="' . esc_url( $dropbox_link ) . '" target="_blank">Dropbox (.mp4)</a></li>';
@@ -113,11 +119,14 @@
 				// directly to the public URL — no server-side file resolution needed.
 				if ( $has_wikimedia ) {
 					if ( $gateway_active && ! $video_disabled ) {
+						$video_intake = \WT\DownloadGateway\IntakeResolver::resolve( $video_id );
 						echo '<li><a href="' . esc_url( $wikimedia_commons_link ) . '" class="gateway-download-link"'
 							. ' data-post-id="' . esc_attr( (string) $video_id ) . '"'
 							. ' data-policy="' . esc_attr( $video_policy ) . '"'
 							. ' data-post-type="videos"'
-							. ' data-file-url="' . esc_attr( $wikimedia_commons_link ) . '">Wikimedia Commons (.webm)</a></li>';
+							. ' data-file-url="' . esc_attr( $wikimedia_commons_link ) . '"'
+							. ' data-intake-set="' . esc_attr( $video_intake['set'] ) . '"'
+							. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '">Wikimedia Commons (.webm)</a></li>';
 					} else {
 						echo '<li><a href="' . esc_url( $wikimedia_commons_link ) . '" target="_blank">Wikimedia Commons (.webm)</a></li>';
 					}


### PR DESCRIPTION
## Summary

- **Session cookie** — `gateway_gated` changed from 30-day to session-scoped; gate fires on every new browser session
- **Named intake field sets** — `gateway_intake_fields` filter now keyed by set name (e.g. `'standard'`) instead of post type slug; JS payload renamed `intakeSteps` → `intakeSets`
- **IntakeResolver** — new class implementing 3-tier resolution (per-record postmeta → per-CPT wp_option → global wp_option) for both the field set name and the `always` flag
- **SettingsRepository** — 4 new intake accessors + option key constants for global and per-CPT intake settings
- **Admin UI** — Settings page gains an "Intake forms" section (global set dropdown, global always select, per-CPT rows); resource metabox gains "Intake form" and "Show on repeat downloads" selects
- **Download_Shortcode + meta--videos-single.php** — all gateway download links now emit `data-intake-set` and `data-intake-always` attributes
- **JS** — `openModal` and `doSilentPassthrough` accept intake params; passthrough with `intakeAlways=true` shows the intake step instead of proceeding directly to download

## Test plan

- [x] `composer test` — 187 tests, 270 assertions, all green
- [x] `composer lint` — clean
- [x] Session cookie: download a gated file → gate appears → submit → download. Close browser entirely → reopen → click same link → gate appears again (not skipped)
- [x] Passthrough within session: download a second file without closing the browser → gate skipped silently
- [x] Intake set: register a named set via `gateway_intake_fields` filter, assign it to a CPT in Settings → Download Gateway → intake step appears after gate submit for that CPT
- [x] Per-record override: set `_gateway_intake_set = 'none'` on one post in a CPT that has a default set → intake skipped for that post only
- [x] Always flag: set "Show on repeat downloads = Yes" for a CPT → first download shows gate + intake; second download in same session (passthrough) still shows intake step
- [x] `data-intake-set` and `data-intake-always` attributes visible in rendered HTML for shortcode links and video template links
- [x] Settings page: "Intake forms" section renders correctly; saving persists values; per-CPT rows show inherit/set/always dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)