### PR TITLE
feat(gateway): sub-phase 7 — GA4 dataLayer forwarding

### DIFF
--- a/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
+++ b/wp-content/plugins/download-gateway/assets/js/gateway-modal.js
@@ -23,6 +23,15 @@
 	var PERSON_LEVEL_KEYS = [ 'community', 'organization' ];
 
 	// -------------------------------------------------------------------------
+	// Analytics helpers
+	// -------------------------------------------------------------------------
+
+	function pushEvent( payload ) {
+		window.dataLayer = window.dataLayer || [];
+		window.dataLayer.push( payload );
+	}
+
+	// -------------------------------------------------------------------------
 	// Cookie helpers
 	// -------------------------------------------------------------------------
 
@@ -165,7 +174,9 @@
 	var currentIsExternal   = false;
 	var currentIntakeSet    = '';
 	var currentIntakeAlways = false;
-	var currentPolicy       = '';
+	var currentPolicy         = '';
+	var currentLanguageSlug   = null;
+	var currentDownloadSource = '';
 
 	// Element focused before the modal opened — restored when it closes.
 	var lastFocusedElement  = null;
@@ -247,8 +258,10 @@
 		currentDirectUrl    = null;
 		currentIsExternal   = false;
 		currentIntakeSet    = '';
-		currentIntakeAlways = false;
-		currentPolicy       = '';
+		currentIntakeAlways   = false;
+		currentPolicy         = '';
+		currentLanguageSlug   = null;
+		currentDownloadSource = '';
 		clearPending();
 		// Return focus to wherever the user was before opening the modal.
 		if ( lastFocusedElement && typeof lastFocusedElement.focus === 'function' ) {
@@ -434,6 +447,15 @@
 					return;
 				}
 				setCookie( 'gateway_gated', result.data.person_cookie, 0 );
+				pushEvent( {
+					event:            'resource_download_gate_submit',
+					post_id:          currentPostId,
+					post_type:        currentPostType,
+					policy:           currentPolicy,
+					language_slug:    currentLanguageSlug,
+					download_source:  currentDownloadSource,
+					consent_download: consent,
+				} );
 				proceedAfterGate(
 					result.data.token,
 					result.data.person_cookie,
@@ -466,6 +488,14 @@
 	 * the download starts — accepted limitation, file still downloads.
 	 */
 	function proceedToDownload( token, directUrl, isExternal ) {
+		pushEvent( {
+			event:           'resource_download_redirect',
+			post_id:         pendingPostId || currentPostId,
+			post_type:       pendingPostType || currentPostType,
+			policy:          currentPolicy,
+			language_slug:   currentLanguageSlug,
+			download_source: currentDownloadSource,
+		} );
 		if ( isExternal || ! token ) {
 			closeModal();
 			redirect( directUrl );
@@ -725,13 +755,28 @@
 			return;
 		}
 
-		var policy = link.dataset.policy;
+		var policy       = link.dataset.policy;
+		var languageSlug = link.dataset.languageSlug || null;
+		var dlSource     = link.dataset.downloadSource || '';
+
+		pushEvent( {
+			event:           'resource_download_click',
+			post_id:         link.dataset.postId,
+			post_type:       link.dataset.postType,
+			policy:          policy,
+			language_slug:   languageSlug,
+			download_source: dlSource,
+		} );
+
 		if ( ! policy || policy === 'none' ) {
 			// No gate — let browser follow the link naturally.
 			return;
 		}
 
 		e.preventDefault();
+
+		currentLanguageSlug   = languageSlug;
+		currentDownloadSource = dlSource;
 
 		var isExternal   = !! link.dataset.fileUrl;
 		var directUrl    = link.dataset.fileUrl || link.href;

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -195,8 +195,8 @@ class Settings_Page {
 	private static function policy_label( string $policy ): string {
 		$labels = array(
 			SettingsRepository::POLICY_NONE     => 'None',
-			SettingsRepository::POLICY_SOFT     => 'Soft gate',
-			SettingsRepository::POLICY_HARD     => 'Hard gate',
+			SettingsRepository::POLICY_SOFT     => 'Skippable',
+			SettingsRepository::POLICY_HARD     => 'Required',
 			SettingsRepository::POLICY_DISABLED => 'Disabled',
 			SettingsRepository::POLICY_INHERIT  => 'Inherit',
 		);

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -209,9 +209,9 @@ class Settings_Page {
 		if ( $include_inherit ) {
 			echo '<option value="" ' . selected( $current, '', false ) . '>Inherit</option>';
 		}
-		echo '<option value="none" ' . selected( $current, 'none', false ) . '>None — no intake form</option>';
+		echo '<option value="none" ' . selected( $current, 'none', false ) . '>None</option>';
 		foreach ( $registered_sets as $set_name ) {
-			echo '<option value="' . esc_attr( $set_name ) . '" ' . selected( $current, $set_name, false ) . '>' . esc_html( $set_name ) . '</option>';
+			echo '<option value="' . esc_attr( $set_name ) . '" ' . selected( $current, $set_name, false ) . '>' . esc_html( ucfirst( $set_name ) ) . '</option>';
 		}
 		echo '</select>';
 	}
@@ -222,8 +222,8 @@ class Settings_Page {
 		if ( $include_inherit ) {
 			echo '<option value="" ' . selected( $current, '', false ) . '>Inherit</option>';
 		}
-		echo '<option value="0" ' . selected( $current, '0', false ) . '>No — first download only</option>';
-		echo '<option value="1" ' . selected( $current, '1', false ) . '>Yes — every session</option>';
+		echo '<option value="0" ' . selected( $current, '0', false ) . '>First only</option>';
+		echo '<option value="1" ' . selected( $current, '1', false ) . '>Every session</option>';
 		echo '</select>';
 	}
 
@@ -233,10 +233,10 @@ class Settings_Page {
 		if ( $include_inherit ) {
 			echo '<option value="' . esc_attr( SettingsRepository::POLICY_INHERIT ) . '" ' . selected( $current, SettingsRepository::POLICY_INHERIT, false ) . '>Inherit</option>';
 		}
-		echo '<option value="none" ' . selected( $current, 'none', false ) . '>None — direct redirect</option>';
-		echo '<option value="soft" ' . selected( $current, 'soft', false ) . '>Soft gate — skippable prompt</option>';
-		echo '<option value="hard" ' . selected( $current, 'hard', false ) . '>Hard gate — email required</option>';
-		echo '<option value="disabled" ' . selected( $current, 'disabled', false ) . '>Disabled — hide download link</option>';
+		echo '<option value="none"     ' . selected( $current, 'none', false ) . '>None</option>';
+		echo '<option value="soft"     ' . selected( $current, 'soft', false ) . '>Skippable</option>';
+		echo '<option value="hard"     ' . selected( $current, 'hard', false ) . '>Required</option>';
+		echo '<option value="disabled" ' . selected( $current, 'disabled', false ) . '>Disabled</option>';
 		echo '</select>';
 	}
 
@@ -271,220 +271,221 @@ class Settings_Page {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$retention_result = isset( $_GET['retention_result'] ) ? (int) $_GET['retention_result'] : null;
 		?>
+		<style>
+			.gateway-legend { display:flex; flex-wrap:wrap; gap:1em 2em; margin:1em 0 0; padding:1em; background:#f6f7f7; border:1px solid #dcdcde; border-radius:3px; }
+			.gateway-legend dt { font-weight:600; }
+			.gateway-legend dd { margin:0 0 0 0.4em; display:inline; color:#50575e; }
+			.gateway-legend span { display:flex; gap:0.3em; }
+		</style>
 		<div class="wrap">
 			<h1>Download Gateway</h1>
-			<p>
-				Version <?php echo esc_html( GATEWAY_VERSION ); ?>
-				&nbsp;&mdash;&nbsp;
-				<?php // @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php) ?>
-				Status: <strong><?php echo GATEWAY_ENABLED ? '<span style="color:#0a0;">Enabled</span>' : '<span style="color:#a00;">Disabled</span>'; ?></strong>
+			<p style="max-width:600px; color:#50575e;">
+				Controls how visitors access downloadable resources — videos, captions, and documents.
+				You can require visitors to share their name and email before downloading, ask follow-up questions, and automatically send that information to your CRM.
 			</p>
 			<?php // @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php) ?>
 			<?php if ( ! GATEWAY_ENABLED ) : ?>
-			<div class="notice notice-warning inline">
-				<p>
-					The gateway is not yet intercepting downloads.
-					Add <code>define( 'GATEWAY_ENABLED', true );</code> to <code>wp-config.php</code> to enable it.
-				</p>
+			<div class="notice notice-error inline" style="margin-bottom:1em;">
+				<p><strong>Gateway is inactive.</strong> Downloads are not being tracked or gated. Contact your developer to enable it.</p>
 			</div>
 			<?php endif; ?>
-
-			<h2 class="title">Dropbox integration</h2>
-			<?php if ( SettingsRepository::dropbox_configured() ) : ?>
-			<p class="description">&#10003; Dropbox credentials found in wp-config.php. Test by downloading a video.</p>
-			<?php else : ?>
-			<p class="description">&#10007; Dropbox not configured &mdash; define <code>GATEWAY_DROPBOX_APP_KEY</code>, <code>GATEWAY_DROPBOX_APP_SECRET</code>, and <code>GATEWAY_DROPBOX_REFRESH_TOKEN</code> in wp-config.php.</p>
-			<?php endif; ?>
-
-			<hr />
 
 			<form method="post">
 				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_FIELD ); ?>
 
-				<h2 class="title">Gate policy</h2>
-				<p>
-					Policies resolve in order: per-resource override → per-CPT default → global default.<br />
-					<em>Disabled</em> hides the download link entirely. <em>Inherit</em> falls through to the next tier.
+				<div class="card" style="max-width:none; margin-bottom:1.5em;">
+					<h2 class="title">Download access</h2>
+					<p style="color:#50575e;">
+						Set whether visitors must share their details to download, and whether to show a follow-up form asking how they plan to use the resource.
+						The <strong>Global</strong> row is the default for all content. Per-content-type rows override it. Individual resources can be further customised from their edit screen.
+						<?php if ( empty( $registered_sets ) ) : ?>
+						<br /><em>No intake forms are currently configured.</em>
+						<?php endif; ?>
+					</p>
+
+					<table class="widefat striped" style="margin-top:1em;">
+						<thead>
+							<tr>
+								<th rowspan="2" style="vertical-align:bottom;">Content type</th>
+								<th rowspan="2" style="vertical-align:bottom;">Access</th>
+								<th colspan="2" style="text-align:center; border-bottom:1px solid #ccd0d4;">Follow-up form</th>
+							</tr>
+							<tr>
+								<th>Form</th>
+								<th>Ask every time?</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr style="background:#f0f6fc;">
+								<td><strong>Global default</strong></td>
+								<td><?php self::policy_select( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $current_policy, false ); ?></td>
+								<td><?php self::intake_set_select( SettingsRepository::OPTION_GLOBAL_INTAKE_SET, $current_intake_set, $registered_sets, false ); ?></td>
+								<td><?php self::intake_always_select( SettingsRepository::OPTION_GLOBAL_INTAKE_ALWAYS, $current_intake_always, false ); ?></td>
+							</tr>
+							<?php foreach ( $post_types as $post_type ) : ?>
+								<?php
+								$cpt_policy        = SettingsRepository::get_cpt_policy( $post_type ) ?? SettingsRepository::POLICY_INHERIT;
+								$cpt_intake_set    = SettingsRepository::get_cpt_intake_set( $post_type ) ?? '';
+								$cpt_intake_always = SettingsRepository::get_cpt_intake_always( $post_type );
+								$cpt_always_value  = null === $cpt_intake_always ? '' : ( $cpt_intake_always ? '1' : '0' );
+								$pt_obj            = get_post_type_object( $post_type );
+								$pt_label          = $pt_obj ? $pt_obj->labels->name : ucwords( str_replace( '_', ' ', $post_type ) );
+								?>
+							<tr>
+								<td><?php echo esc_html( $pt_label ); ?></td>
+								<td><?php self::policy_select( 'gateway_cpt_policy_' . $post_type, $cpt_policy ); ?></td>
+								<td><?php self::intake_set_select( SettingsRepository::OPTION_CPT_INTAKE_SET_PREFIX . $post_type, $cpt_intake_set, $registered_sets ); ?></td>
+								<td><?php self::intake_always_select( SettingsRepository::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type, $cpt_always_value ); ?></td>
+							</tr>
+							<?php endforeach; ?>
+						</tbody>
+					</table>
+
+					<dl class="gateway-legend">
+						<span><dt>Inherit</dt><dd>— use the row above</dd></span>
+						<span><dt>None</dt><dd>— open download, no prompt</dd></span>
+						<span><dt>Skippable</dt><dd>— ask for details, visitor can decline</dd></span>
+						<span><dt>Required</dt><dd>— email required before downloading</dd></span>
+						<span><dt>Disabled</dt><dd>— download link hidden entirely</dd></span>
+					</dl>
+				</div>
+
+				<div class="card" style="max-width:none; margin-bottom:1.5em;">
+					<h2 class="title">Integrations</h2>
+
+					<h3 style="margin-bottom:4px;">Dropbox</h3>
+					<?php if ( SettingsRepository::dropbox_configured() ) : ?>
+					<p class="description">&#10003; Connected. Video and caption files are served via Dropbox.</p>
+					<?php else : ?>
+					<p class="description">&#10007; Not connected &mdash; video and caption downloads will not work. Contact your developer to configure Dropbox.</p>
+					<?php endif; ?>
+
+					<h3 style="margin-top:1.5em; margin-bottom:4px;">CRM &amp; email notifications</h3>
+					<p style="color:#50575e;">
+						When someone downloads a resource or submits the follow-up form, the gateway can notify your CRM or email platform automatically.
+						Paste the webhook URL from Make.com below. Leave blank to disable notifications.
+					</p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="gateway_webhook_endpoint">Notification URL</label>
+							</th>
+							<td>
+								<input
+									type="url"
+									name="<?php echo esc_attr( SettingsRepository::OPTION_WEBHOOK_ENDPOINT ); ?>"
+									id="gateway_webhook_endpoint"
+									value="<?php echo esc_attr( SettingsRepository::get_webhook_endpoint() ); ?>"
+									placeholder="https://hook.make.com/…"
+									style="width:420px;"
+								/>
+								<p class="description">
+									Notifies your CRM when a visitor registers, downloads a resource, or submits a follow-up form.
+									<?php if ( '' !== SettingsRepository::get_webhook_endpoint() ) : ?>
+									<span style="color:#0a0;">&#10003; Configured.</span>
+									<?php endif; ?>
+								</p>
+							</td>
+						</tr>
+					</table>
+				</div>
+
+				<div class="card" style="max-width:none; margin-bottom:1.5em;">
+					<h2 class="title">Data privacy</h2>
+					<p style="color:#50575e;">
+						To comply with data protection regulations, visitor names and email addresses are automatically deleted after the period below.
+						Download history is preserved so usage data remains intact — only personal identifiers are removed.
+					</p>
+					<table class="form-table" role="presentation">
+						<tr>
+							<th scope="row">
+								<label for="gateway_retention_months">Delete personal data after</label>
+							</th>
+							<td>
+								<input
+									type="number"
+									name="<?php echo esc_attr( SettingsRepository::OPTION_RETENTION_MONTHS ); ?>"
+									id="gateway_retention_months"
+									value="<?php echo esc_attr( (string) $current_retention_months ); ?>"
+									min="1"
+									max="120"
+									style="width:80px;"
+								/> months
+								<p class="description">Recommended: 24 months. Names and email addresses older than this are automatically removed once per day.</p>
+							</td>
+						</tr>
+					</table>
+				</div>
+
+				<?php submit_button( 'Save settings' ); ?>
+			</form>
+
+			<div class="card" style="max-width:none; margin-bottom:1.5em;">
+				<h2 class="title">Individual resource overrides</h2>
+				<p style="color:#50575e;">
+					These resources have a custom access setting that differs from their content type default.
+					To change a resource's setting, open it in the editor and look for the Download Gateway panel in the sidebar.
+				</p>
+				<?php if ( empty( $audit_rows ) ) : ?>
+				<p><em>No overrides set — all resources use their content type or global default.</em></p>
+				<?php else : ?>
+				<table class="widefat striped" style="margin-top:1em;">
+					<thead>
+						<tr>
+							<th>Resource</th>
+							<th>Content type</th>
+							<th>Access</th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ( $audit_rows as $row ) : ?>
+						<tr>
+							<td>
+								<a href="<?php echo esc_url( get_edit_post_link( $row['post_id'] ) ); ?>">
+									<?php echo esc_html( $row['post_title'] ?: '(no title)' ); ?>
+								</a>
+							</td>
+							<td>
+								<?php
+								$pt_obj = get_post_type_object( $row['post_type'] );
+								echo esc_html( $pt_obj ? $pt_obj->labels->name : ucwords( str_replace( '_', ' ', $row['post_type'] ) ) );
+								?>
+							</td>
+							<td><?php echo esc_html( self::policy_label( $row['policy'] ) ); ?></td>
+						</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+				<?php endif; ?>
+			</div>
+
+			<div class="card" style="max-width:none; margin-bottom:1.5em;">
+				<h2 class="title">Privacy cleanup</h2>
+				<p style="color:#50575e;">
+					This runs automatically once per day and removes personal data older than your retention period.
+					You can also run it manually below — for example, after updating the retention period.
 				</p>
 
-				<table class="form-table" role="presentation">
-					<tr>
-						<th scope="row">Global default</th>
-						<td>
-							<?php self::policy_select( SettingsRepository::OPTION_GLOBAL_GATE_POLICY, $current_policy, false ); ?>
-							<p class="description">Site-wide fallback when no per-CPT or per-resource override is set.</p>
-						</td>
-					</tr>
+				<?php if ( null !== $retention_result ) : ?>
+				<div class="notice notice-success inline">
+					<p>Cleanup complete &mdash; <strong><?php echo esc_html( (string) $retention_result ); ?></strong> subscriber record(s) anonymized.</p>
+				</div>
+				<?php endif; ?>
 
-					<?php foreach ( $post_types as $post_type ) : ?>
-						<?php $cpt_policy = SettingsRepository::get_cpt_policy( $post_type ) ?? SettingsRepository::POLICY_INHERIT; ?>
-					<tr>
-						<th scope="row"><?php echo esc_html( $post_type ); ?></th>
-						<td>
-							<?php self::policy_select( 'gateway_cpt_policy_' . $post_type, $cpt_policy ); ?>
-						</td>
-					</tr>
-					<?php endforeach; ?>
-				</table>
-
-				<h2 class="title">Intake forms</h2>
 				<p>
-					Intake forms are an optional step 2 shown after the gate, collecting supplementary information.
-					Field sets are registered via the <code>gateway_intake_fields</code> PHP filter.
-					<?php if ( empty( $registered_sets ) ) : ?>
-					<br /><em>No intake field sets are currently registered.</em>
+					<?php if ( is_array( $last_run ) ) : ?>
+					Last run: <strong><?php echo esc_html( $last_run['timestamp'] ?? '—' ); ?></strong>
+					&mdash; <?php echo esc_html( (string) ( $last_run['count'] ?? 0 ) ); ?> record(s) anonymized.
+					<?php else : ?>
+					<em>Has not run yet.</em>
 					<?php endif; ?>
 				</p>
 
-				<table class="form-table" role="presentation">
-					<tr>
-						<th scope="row">Global default set</th>
-						<td>
-							<?php self::intake_set_select( SettingsRepository::OPTION_GLOBAL_INTAKE_SET, $current_intake_set, $registered_sets, false ); ?>
-							<p class="description">Fallback intake set when no per-CPT or per-resource override is set.</p>
-						</td>
-					</tr>
-					<tr>
-						<th scope="row">Show on repeat downloads (global)</th>
-						<td>
-							<?php self::intake_always_select( SettingsRepository::OPTION_GLOBAL_INTAKE_ALWAYS, $current_intake_always, false ); ?>
-							<p class="description">When set to "Yes", the intake form also appears for returning visitors downloading again within the same session.</p>
-						</td>
-					</tr>
-
-					<?php foreach ( $post_types as $post_type ) : ?>
-						<?php
-						$cpt_intake_set    = SettingsRepository::get_cpt_intake_set( $post_type ) ?? '';
-						$cpt_intake_always = SettingsRepository::get_cpt_intake_always( $post_type );
-						$cpt_always_value  = null === $cpt_intake_always ? '' : ( $cpt_intake_always ? '1' : '0' );
-						?>
-					<tr>
-						<th scope="row"><?php echo esc_html( $post_type ); ?></th>
-						<td>
-							<?php self::intake_set_select( SettingsRepository::OPTION_CPT_INTAKE_SET_PREFIX . $post_type, $cpt_intake_set, $registered_sets ); ?>
-							&nbsp;
-							<?php self::intake_always_select( SettingsRepository::OPTION_CPT_INTAKE_ALWAYS_PREFIX . $post_type, $cpt_always_value ); ?>
-							<p class="description">Set &nbsp;/&nbsp; Always show</p>
-						</td>
-					</tr>
-					<?php endforeach; ?>
-				</table>
-
-				<h2 class="title">Data retention</h2>
-				<table class="form-table" role="presentation">
-					<tr>
-						<th scope="row">
-							<label for="gateway_retention_months">Retention window</label>
-						</th>
-						<td>
-							<input
-								type="number"
-								name="<?php echo esc_attr( SettingsRepository::OPTION_RETENTION_MONTHS ); ?>"
-								id="gateway_retention_months"
-								value="<?php echo esc_attr( (string) $current_retention_months ); ?>"
-								min="1"
-								max="120"
-								style="width:80px;"
-							/> months
-							<p class="description">
-								Email and name are nulled out after this many months.
-								The person record itself is kept so download history remains intact.
-							</p>
-						</td>
-					</tr>
-				</table>
-
-				<h2 class="title">Integrations</h2>
-				<p>
-					Webhook events are sent to a single endpoint for all three event types
-					(<code>person</code>, <code>download</code>, <code>intake</code>).
-					Leave blank to disable webhook delivery.
-				</p>
-				<table class="form-table" role="presentation">
-					<tr>
-						<th scope="row">
-							<label for="gateway_webhook_endpoint">Webhook endpoint URL</label>
-						</th>
-						<td>
-							<input
-								type="url"
-								name="<?php echo esc_attr( SettingsRepository::OPTION_WEBHOOK_ENDPOINT ); ?>"
-								id="gateway_webhook_endpoint"
-								value="<?php echo esc_attr( SettingsRepository::get_webhook_endpoint() ); ?>"
-								placeholder="https://hook.make.com/…"
-								style="width:420px;"
-							/>
-							<p class="description">
-								Receives <code>person</code>, <code>download</code>, and <code>intake</code> events.
-								Deliveries are retried up to 5 times with exponential backoff.
-							</p>
-						</td>
-					</tr>
-				</table>
-
-			<?php submit_button( 'Save settings' ); ?>
-			</form>
-
-			<hr />
-
-			<h2>Per-resource overrides</h2>
-
-			<?php if ( empty( $audit_rows ) ) : ?>
-			<p>No per-resource policy overrides are set. All resources use their CPT or global default.</p>
-			<?php else : ?>
-			<table class="widefat striped" style="max-width:700px;">
-				<thead>
-					<tr>
-						<th>Post</th>
-						<th>Type</th>
-						<th>Policy</th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php foreach ( $audit_rows as $row ) : ?>
-					<tr>
-						<td>
-							<a href="<?php echo esc_url( get_edit_post_link( $row['post_id'] ) ); ?>">
-								<?php echo esc_html( $row['post_title'] ?: '(no title)' ); ?>
-							</a>
-						</td>
-						<td><?php echo esc_html( $row['post_type'] ); ?></td>
-						<td><?php echo esc_html( self::policy_label( $row['policy'] ) ); ?></td>
-					</tr>
-					<?php endforeach; ?>
-				</tbody>
-			</table>
-			<?php endif; ?>
-
-			<hr />
-
-			<h2>Retention</h2>
-
-			<?php if ( null !== $retention_result ) : ?>
-			<div class="notice notice-success inline">
-				<p>Retention job completed: <strong><?php echo esc_html( (string) $retention_result ); ?></strong> record(s) anonymized.</p>
+				<form method="post">
+					<?php wp_nonce_field( self::NONCE_ACTION_RUN_NOW, self::NONCE_FIELD_RUN_NOW ); ?>
+					<?php submit_button( 'Run cleanup now', 'secondary' ); ?>
+				</form>
 			</div>
-			<?php endif; ?>
-
-			<?php if ( is_array( $last_run ) ) : ?>
-			<p>
-				Last run: <strong><?php echo esc_html( $last_run['timestamp'] ?? '—' ); ?></strong>
-				&mdash; <?php echo esc_html( (string) ( $last_run['count'] ?? 0 ) ); ?> record(s) anonymized.
-			</p>
-			<?php else : ?>
-			<p>The retention job has not run yet.</p>
-			<?php endif; ?>
-
-			<p>
-				The retention job also runs automatically once per day via WP-Cron.
-				On production, back it up with a server cron:
-				<code>wp cron event run --due-now</code>
-			</p>
-
-			<form method="post">
-				<?php wp_nonce_field( self::NONCE_ACTION_RUN_NOW, self::NONCE_FIELD_RUN_NOW ); ?>
-				<?php submit_button( 'Run retention now', 'secondary' ); ?>
-			</form>
 		</div>
 		<?php
 	}

--- a/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
+++ b/wp-content/plugins/download-gateway/includes/admin/class-settings-page.php
@@ -279,7 +279,7 @@ class Settings_Page {
 		</style>
 		<div class="wrap">
 			<h1>Download Gateway</h1>
-			<p style="max-width:600px; color:#50575e;">
+			<p style="color:#50575e;">
 				Controls how visitors access downloadable resources — videos, captions, and documents.
 				You can require visitors to share their name and email before downloading, ask follow-up questions, and automatically send that information to your CRM.
 			</p>

--- a/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-shortcode.php
@@ -32,8 +32,10 @@ class Download_Shortcode {
 		// @phpstan-ignore-next-line (unreachable only in static analysis — runtime value differs)
 		$atts = shortcode_atts(
 			array(
-				'id'    => '',
-				'label' => 'Download',
+				'id'            => '',
+				'label'         => 'Download',
+				'source'        => '',
+				'language_slug' => '',
 			),
 			$atts,
 			'gateway_download'
@@ -50,18 +52,29 @@ class Download_Shortcode {
 			return '';
 		}
 
-		$url       = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
-		$post_type = get_post_type( $post_id ) ?: '';
-		$intake    = IntakeResolver::resolve( $post_id );
+		$url           = rest_url( GATEWAY_REST_NAMESPACE . '/download/' . $post_id );
+		$post_type     = get_post_type( $post_id ) ?: '';
+		$intake        = IntakeResolver::resolve( $post_id );
+		$source        = sanitize_key( $atts['source'] );
+		$language_slug = sanitize_key( $atts['language_slug'] );
+
+		$extra = '';
+		if ( '' !== $source ) {
+			$extra .= ' data-download-source="' . esc_attr( $source ) . '"';
+		}
+		if ( '' !== $language_slug ) {
+			$extra .= ' data-language-slug="' . esc_attr( $language_slug ) . '"';
+		}
 
 		return sprintf(
-			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s" data-post-type="%s" data-intake-set="%s" data-intake-always="%s">%s</a>',
+			'<a href="%s" class="gateway-download-link" data-post-id="%d" data-policy="%s" data-post-type="%s" data-intake-set="%s" data-intake-always="%s"%s>%s</a>',
 			esc_url( $url ),
 			$post_id,
 			esc_attr( $policy ),
 			esc_attr( $post_type ),
 			esc_attr( $intake['set'] ),
 			$intake['always'] ? '1' : '0',
+			$extra,
 			esc_html( $atts['label'] )
 		);
 	}

--- a/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
+++ b/wp-content/plugins/download-gateway/includes/class-resource-metabox.php
@@ -89,25 +89,25 @@ class Resource_Metabox {
 		?>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Gate policy</p>
 		<select name="_gateway_gate_policy" style="width:100%;margin-bottom:10px;">
-			<option value=""       <?php selected( $policy, '' ); ?>>Inherit (use CPT / global default)</option>
-			<option value="none"     <?php selected( $policy, 'none' ); ?>>None — direct redirect</option>
-			<option value="soft"     <?php selected( $policy, 'soft' ); ?>>Soft gate — skippable prompt</option>
-			<option value="hard"     <?php selected( $policy, 'hard' ); ?>>Hard gate — email required</option>
-			<option value="disabled" <?php selected( $policy, 'disabled' ); ?>>Disabled — hide download link</option>
+			<option value=""         <?php selected( $policy, '' ); ?>>Inherit</option>
+			<option value="none"     <?php selected( $policy, 'none' ); ?>>None</option>
+			<option value="soft"     <?php selected( $policy, 'soft' ); ?>>Skippable</option>
+			<option value="hard"     <?php selected( $policy, 'hard' ); ?>>Required</option>
+			<option value="disabled" <?php selected( $policy, 'disabled' ); ?>>Disabled</option>
 		</select>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Intake form</p>
 		<select name="_gateway_intake_set" style="width:100%;margin-bottom:6px;">
-			<option value="inherit" <?php selected( $intake_set, 'inherit' ); ?>>Inherit (use CPT / global default)</option>
-			<option value="none"    <?php selected( $intake_set, 'none' ); ?>>None — no intake form</option>
+			<option value="inherit" <?php selected( $intake_set, 'inherit' ); ?>>Inherit</option>
+			<option value="none"    <?php selected( $intake_set, 'none' ); ?>>None</option>
 			<?php foreach ( $registered_sets as $set_name ) : ?>
-			<option value="<?php echo esc_attr( $set_name ); ?>" <?php selected( $intake_set, $set_name ); ?>><?php echo esc_html( $set_name ); ?></option>
+			<option value="<?php echo esc_attr( $set_name ); ?>" <?php selected( $intake_set, $set_name ); ?>><?php echo esc_html( ucfirst( $set_name ) ); ?></option>
 			<?php endforeach; ?>
 		</select>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Show intake on repeat downloads</p>
 		<select name="_gateway_intake_always" style="width:100%;margin-bottom:10px;">
-			<option value="inherit" <?php selected( $intake_always, 'inherit' ); ?>>Inherit (use CPT / global default)</option>
-			<option value="0"       <?php selected( $intake_always, '0' ); ?>>No — first download only</option>
-			<option value="1"       <?php selected( $intake_always, '1' ); ?>>Yes — every session</option>
+			<option value="inherit" <?php selected( $intake_always, 'inherit' ); ?>>Inherit</option>
+			<option value="0"       <?php selected( $intake_always, '0' ); ?>>First only</option>
+			<option value="1"       <?php selected( $intake_always, '1' ); ?>>Every session</option>
 		</select>
 		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Download URL</p>
 		<input
@@ -117,9 +117,15 @@ class Resource_Metabox {
 			style="width:100%;font-size:11px;margin-bottom:6px;"
 			onclick="this.select();"
 		/>
-		<p style="margin:0 0 6px;font-size:11px;color:#646970;">
-			Shortcode: <code>[gateway_download id="<?php echo esc_html( (string) $post->ID ); ?>"]</code>
-		</p>
+		<p style="margin:0 0 4px;font-size:11px;font-weight:600;">Shortcode</p>
+		<input
+			type="text"
+			readonly
+			value="[gateway_download id=&quot;<?php echo esc_attr( (string) $post->ID ); ?>&quot;]"
+			style="width:100%;font-size:11px;margin-bottom:6px;cursor:pointer;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;"
+			onclick="navigator.clipboard.writeText(this.value);this.select();"
+			title="Click to copy"
+		/>
 		<?php // @phpstan-ignore-next-line (runtime constant — value is overridden in wp-config.php) ?>
 		<?php if ( ! GATEWAY_ENABLED ) : ?>
 		<p style="margin:4px 0 0;font-size:11px;color:#a00;">

--- a/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
+++ b/wp-content/themes/blankslate-child/modules/videos/meta--videos-single.php
@@ -13,8 +13,11 @@
 		// Get captions linked to this video.
 		// source_video is an ACF post_object field but the sync stores the value
 		// as a serialized array, so we match against the serialized form with LIKE.
-		$video_id = get_the_ID();
-		$captions = get_posts(
+		$video_id      = get_the_ID();
+		$language_slug = ( ! empty( $featured_languages ) && isset( $featured_languages[0]->post_name ) )
+			? $featured_languages[0]->post_name
+			: null;
+		$captions      = get_posts(
 			array(
 				'post_type'      => 'captions',
 				'posts_per_page' => -1,
@@ -63,7 +66,9 @@
 							. ' data-policy="' . esc_attr( $caption_policy ) . '"'
 							. ' data-post-type="captions"'
 							. ' data-intake-set="' . esc_attr( $caption_intake['set'] ) . '"'
-							. ' data-intake-always="' . ( $caption_intake['always'] ? '1' : '0' ) . '">'
+							. ' data-intake-always="' . ( $caption_intake['always'] ? '1' : '0' ) . '"'
+							. ( $language_slug ? ' data-language-slug="' . esc_attr( $language_slug ) . '"' : '' )
+							. ' data-download-source="resource-page">'
 							. esc_html( $label ) . ' (.srt)</a></li>';
 					}
 				} else {
@@ -108,7 +113,9 @@
 								. ' data-policy="' . esc_attr( $video_policy ) . '"'
 								. ' data-post-type="videos"'
 								. ' data-intake-set="' . esc_attr( $video_intake['set'] ) . '"'
-								. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '">Dropbox (.mp4)</a></li>';
+								. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '"'
+								. ( $language_slug ? ' data-language-slug="' . esc_attr( $language_slug ) . '"' : '' )
+								. ' data-download-source="resource-page">Dropbox (.mp4)</a></li>';
 						}
 					} else {
 						echo '<li><a href="' . esc_url( $dropbox_link ) . '" target="_blank">Dropbox (.mp4)</a></li>';
@@ -126,7 +133,9 @@
 							. ' data-post-type="videos"'
 							. ' data-file-url="' . esc_attr( $wikimedia_commons_link ) . '"'
 							. ' data-intake-set="' . esc_attr( $video_intake['set'] ) . '"'
-							. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '">Wikimedia Commons (.webm)</a></li>';
+							. ' data-intake-always="' . ( $video_intake['always'] ? '1' : '0' ) . '"'
+							. ( $language_slug ? ' data-language-slug="' . esc_attr( $language_slug ) . '"' : '' )
+							. ' data-download-source="resource-page">Wikimedia Commons (.webm)</a></li>';
 					} else {
 						echo '<li><a href="' . esc_url( $wikimedia_commons_link ) . '" target="_blank">Wikimedia Commons (.webm)</a></li>';
 					}


### PR DESCRIPTION
## Summary

- Adds `pushEvent()` helper in `gateway-modal.js` that wraps `window.dataLayer.push()`
- Fires three events for GTM to pick up and forward to GA4:
  - `resource_download_click` — on every `.gateway-download-link` click (gated and ungated)
  - `resource_download_gate_submit` — after successful gate form submission + cookie set
  - `resource_download_redirect` — at the start of `proceedToDownload()`, before redirect
- Each event carries `post_id`, `post_type`, `policy`, `language_slug`, `download_source` (plus `consent_download` on gate_submit)
- Adds `data-language-slug` and `data-download-source="resource-page"` to all three gateway links in the video single template (Dropbox, Wikimedia, captions)
- Adds `source` and `language_slug` shortcode attributes to `[gateway_download]` for use on language pages and archives

## GTM setup still needed (in GTM, not in code)
- Three Custom Event triggers: `resource_download_click`, `resource_download_gate_submit`, `resource_download_redirect`
- Data Layer Variables for each parameter
- GA4 Event tags wired to each trigger

## Test plan
- [ ] Click a gated download link → `resource_download_click` appears in dataLayer (browser console: `window.dataLayer`)
- [ ] Submit gate form → `resource_download_gate_submit` fires with correct `consent_download` value
- [ ] Download completes → `resource_download_redirect` fires with correct `policy` and `download_source`
- [ ] Ungated (`policy=none`) click → `resource_download_click` fires, browser follows link naturally (no modal)
- [x] `composer test` — 202 tests pass
- [x] `composer lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)