### PR TITLE
fix(gateway): bump version to 0.1.12 to bust JS cache

### DIFF
--- a/wp-content/plugins/download-gateway/download-gateway.php
+++ b/wp-content/plugins/download-gateway/download-gateway.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'GATEWAY_VERSION', '0.1.11' );
+define( 'GATEWAY_VERSION', '0.1.12' );
 define( 'GATEWAY_FILE', __FILE__ );
 define( 'GATEWAY_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GATEWAY_REST_NAMESPACE', 'gateway/v1' );


### PR DESCRIPTION
## Summary

- Bumps `GATEWAY_VERSION` from `0.1.11` → `0.1.12`
- The GA4 `dataLayer.push()` code deployed in #578 was cached in browsers under the old version string — this forces a re-download of `gateway-modal.js`

## Test plan
- [ ] After merging and deploying, hard-refresh a video page and confirm `resource_download_click` appears in `window.dataLayer` on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)