### PR TITLE
feat(gateway): enrich webhook payloads with airtable_record_id and download_event_id

### DIFF
--- a/wp-content/plugins/download-gateway/includes/class-download-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-controller.php
@@ -202,13 +202,14 @@ class DownloadController {
 				(int) $event_id,
 				$endpoint,
 				array(
-					'type'       => 'download',
-					'event_id'   => (int) $event_id,
-					'person_id'  => $person_id,
-					'post_id'    => $post_id,
-					'post_type'  => $post_type,
-					'policy'     => PolicyResolver::resolve( $post_id ),
-					'created_at' => current_time( 'mysql' ),
+					'type'               => 'download',
+					'event_id'           => (int) $event_id,
+					'person_id'          => $person_id,
+					'post_id'            => $post_id,
+					'post_type'          => $post_type,
+					'airtable_record_id' => get_post_meta( $post_id, '_airtable_record_id', true ) ?: null,
+					'policy'             => PolicyResolver::resolve( $post_id ),
+					'created_at'         => current_time( 'mysql' ),
 				)
 			);
 		}

--- a/wp-content/plugins/download-gateway/includes/class-download-event-repository.php
+++ b/wp-content/plugins/download-gateway/includes/class-download-event-repository.php
@@ -84,4 +84,34 @@ class DownloadEventRepository {
 
 		return $wpdb->insert_id;
 	}
+
+	/**
+	 * Return the ID of the most recent redirect event for a person + post.
+	 *
+	 * Used by IntakeController to include the download event ID in the intake
+	 * webhook payload so Make.com can update the correct Downloads record.
+	 *
+	 * @param int $person_id Person ID from wp_gateway_people.
+	 * @param int $post_id   Post ID of the downloaded resource.
+	 * @return int|null Row ID, or null if no matching redirect event found.
+	 */
+	public static function find_redirect_id( int $person_id, int $post_id ): ?int {
+		global $wpdb;
+
+		$id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM {$wpdb->prefix}gateway_download_events
+				 WHERE person_id = %d
+				   AND post_id   = %d
+				   AND event_type = %s
+				 ORDER BY created_at DESC
+				 LIMIT 1",
+				$person_id,
+				$post_id,
+				self::EVENT_REDIRECT
+			)
+		);
+
+		return null !== $id ? (int) $id : null;
+	}
 }

--- a/wp-content/plugins/download-gateway/includes/class-intake-controller.php
+++ b/wp-content/plugins/download-gateway/includes/class-intake-controller.php
@@ -101,13 +101,15 @@ class IntakeController {
 				(int) $intake_id,
 				$endpoint,
 				array(
-					'type'       => 'intake',
-					'person_id'  => $person_id,
-					'post_id'    => $post_id,
-					'post_type'  => $post_type,
-					'intake_set' => $intake_set,
-					'responses'  => $sanitized,
-					'created_at' => current_time( 'mysql' ),
+					'type'               => 'intake',
+					'person_id'          => $person_id,
+					'download_event_id'  => DownloadEventRepository::find_redirect_id( $person_id, $post_id ),
+					'post_id'            => $post_id,
+					'post_type'          => $post_type,
+					'airtable_record_id' => get_post_meta( $post_id, '_airtable_record_id', true ) ?: null,
+					'intake_set'         => $intake_set,
+					'responses'          => $sanitized,
+					'created_at'         => current_time( 'mysql' ),
 				)
 			);
 		}


### PR DESCRIPTION
## Summary

- Download webhook payload now includes `airtable_record_id` (from `_airtable_record_id` post meta) to enable Make.com to join Downloads records against the main Airtable tables (Videos, Captions, Lexicons) for metadata like language and resource name
- Intake webhook payload includes the same `airtable_record_id` plus `download_event_id` (ID of the most recent redirect event for the person+post) so Make.com can update the correct Downloads record directly without a search step
- Adds `DownloadEventRepository::find_redirect_id()` as the first read method on that repository

## Test plan

- [ ] Trigger a hard-policy download and verify the webhook payload contains `airtable_record_id` (non-null for posts with `_airtable_record_id` meta, null for posts without)
- [ ] Submit an intake form and verify payload contains both `download_event_id` and `airtable_record_id`
- [ ] Verify Make.com scenario correctly maps `airtable_record_id` → Post Airtable ID field on Downloads record

🤖 Generated with [Claude Code](https://claude.com/claude-code)